### PR TITLE
Add Cost First provider selection strategy

### DIFF
--- a/backend/app/rules/engine.py
+++ b/backend/app/rules/engine.py
@@ -82,6 +82,13 @@ class RuleEngine:
                         target_model=pm.target_model_name,
                         priority=pm.priority,
                         weight=pm.weight,
+                        billing_mode=pm.billing_mode,
+                        input_price=pm.input_price,
+                        output_price=pm.output_price,
+                        per_request_price=pm.per_request_price,
+                        tiered_pricing=pm.tiered_pricing,
+                        model_input_price=model_mapping.input_price,
+                        model_output_price=model_mapping.output_price,
                     )
                 )
         
@@ -131,6 +138,13 @@ class RuleEngine:
                         target_model=pm.target_model_name,
                         priority=pm.priority,
                         weight=pm.weight,
+                        billing_mode=pm.billing_mode,
+                        input_price=pm.input_price,
+                        output_price=pm.output_price,
+                        per_request_price=pm.per_request_price,
+                        tiered_pricing=pm.tiered_pricing,
+                        model_input_price=model_mapping.input_price,
+                        model_output_price=model_mapping.output_price,
                     )
                 )
         

--- a/backend/app/rules/models.py
+++ b/backend/app/rules/models.py
@@ -85,9 +85,9 @@ class RuleSet:
 class CandidateProvider:
     """
     Candidate Provider
-    
+
     Candidate provider information output after rule engine matching.
-    
+
     Attributes:
         provider_id: Provider ID
         provider_name: Provider Name
@@ -97,8 +97,15 @@ class CandidateProvider:
         target_model: Target Model Name (Actual model corresponding to this provider)
         priority: Priority (Lower value means higher priority)
         weight: Weight (Used for weighted selection)
+        billing_mode: Billing mode (token_flat/token_tiered/per_request)
+        input_price: Provider input token price override (USD per 1M tokens)
+        output_price: Provider output token price override (USD per 1M tokens)
+        per_request_price: Per-request price (USD)
+        tiered_pricing: Tiered pricing configuration
+        model_input_price: Model fallback input price (USD per 1M tokens)
+        model_output_price: Model fallback output price (USD per 1M tokens)
     """
-    
+
     provider_id: int
     provider_name: str
     base_url: str
@@ -108,3 +115,10 @@ class CandidateProvider:
     extra_headers: Optional[dict[str, str]] = None
     priority: int = 0
     weight: int = 1
+    billing_mode: Optional[str] = None
+    input_price: Optional[float] = None
+    output_price: Optional[float] = None
+    per_request_price: Optional[float] = None
+    tiered_pricing: Optional[list[Any]] = None
+    model_input_price: Optional[float] = None
+    model_output_price: Optional[float] = None

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -8,7 +8,7 @@ from app.services.model_service import ModelService
 from app.services.api_key_service import ApiKeyService
 from app.services.log_service import LogService
 from app.services.retry_handler import RetryHandler
-from app.services.strategy import SelectionStrategy, RoundRobinStrategy
+from app.services.strategy import SelectionStrategy, RoundRobinStrategy, CostFirstStrategy
 
 __all__ = [
     "ProxyService",
@@ -19,4 +19,5 @@ __all__ = [
     "RetryHandler",
     "SelectionStrategy",
     "RoundRobinStrategy",
+    "CostFirstStrategy",
 ]

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -322,6 +322,7 @@ class ProxyService:
             candidates=candidates,
             requested_model=requested_model,
             forward_fn=forward_fn,
+            input_tokens=input_tokens,
             on_failure_attempt=log_failed_attempt,
         )
 
@@ -633,6 +634,7 @@ class ProxyService:
             candidates,
             requested_model,
             forward_stream_fn,
+            input_tokens=input_tokens,
             on_failure_attempt=log_failed_attempt,
         )
         

--- a/backend/app/services/strategy.py
+++ b/backend/app/services/strategy.py
@@ -7,8 +7,12 @@ Provides implementation for provider selection strategies.
 from abc import ABC, abstractmethod
 from typing import Optional
 import asyncio
+import logging
 
 from app.rules.models import CandidateProvider
+from app.common.costs import resolve_billing, calculate_cost_from_billing
+
+logger = logging.getLogger(__name__)
 
 
 class SelectionStrategy(ABC):
@@ -23,14 +27,16 @@ class SelectionStrategy(ABC):
         self,
         candidates: list[CandidateProvider],
         requested_model: str,
+        input_tokens: Optional[int] = None,
     ) -> Optional[CandidateProvider]:
         """
         Select a provider from the candidate list
-        
+
         Args:
             candidates: List of candidate providers
             requested_model: Requested model name (for state isolation)
-        
+            input_tokens: Number of input tokens (for cost-based selection)
+
         Returns:
             Optional[CandidateProvider]: Selected provider, or None if no provider available
         """
@@ -42,15 +48,17 @@ class SelectionStrategy(ABC):
         candidates: list[CandidateProvider],
         requested_model: str,
         current: CandidateProvider,
+        input_tokens: Optional[int] = None,
     ) -> Optional[CandidateProvider]:
         """
         Get next provider (used for failover)
-        
+
         Args:
             candidates: List of candidate providers
             requested_model: Requested model name
             current: Current provider
-        
+            input_tokens: Number of input tokens (for cost-based selection)
+
         Returns:
             Optional[CandidateProvider]: Next provider, or None if no provider available
         """
@@ -83,14 +91,16 @@ class RoundRobinStrategy(SelectionStrategy):
         self,
         candidates: list[CandidateProvider],
         requested_model: str,
+        input_tokens: Optional[int] = None,
     ) -> Optional[CandidateProvider]:
         """
         Round-robin provider selection
-        
+
         Args:
             candidates: List of candidate providers (sorted by priority)
             requested_model: Requested model name
-        
+            input_tokens: Number of input tokens (unused in round-robin)
+
         Returns:
             Optional[CandidateProvider]: Selected provider
         """
@@ -112,15 +122,17 @@ class RoundRobinStrategy(SelectionStrategy):
         candidates: list[CandidateProvider],
         requested_model: str,
         current: CandidateProvider,
+        input_tokens: Optional[int] = None,
     ) -> Optional[CandidateProvider]:
         """
         Get next provider (used for failover)
-        
+
         Args:
             candidates: List of candidate providers
             requested_model: Requested model name
             current: Current provider
-        
+            input_tokens: Number of input tokens (unused in round-robin)
+
         Returns:
             Optional[CandidateProvider]: Next provider
         """
@@ -147,7 +159,7 @@ class RoundRobinStrategy(SelectionStrategy):
     def reset(self, requested_model: Optional[str] = None) -> None:
         """
         Reset counters (for testing)
-        
+
         Args:
             requested_model: Specific model name, resets all if None
         """
@@ -155,3 +167,185 @@ class RoundRobinStrategy(SelectionStrategy):
             self._counters.pop(requested_model, None)
         else:
             self._counters.clear()
+
+
+class CostFirstStrategy(SelectionStrategy):
+    """
+    Cost First Strategy
+
+    Selects providers based on lowest cost for the current request.
+    Calculates cost based on input tokens and provider billing configuration.
+    Falls back to next lowest cost provider on failure.
+    """
+
+    def _calculate_input_cost(self, candidate: CandidateProvider, input_tokens: int) -> float:
+        """
+        Calculate input cost for a candidate provider
+
+        Args:
+            candidate: Candidate provider with billing information
+            input_tokens: Number of input tokens
+
+        Returns:
+            float: Estimated input cost in USD
+        """
+        # Resolve billing configuration
+        billing = resolve_billing(
+            input_tokens=input_tokens,
+            model_input_price=candidate.model_input_price,
+            model_output_price=candidate.model_output_price,
+            provider_billing_mode=candidate.billing_mode,
+            provider_per_request_price=candidate.per_request_price,
+            provider_tiered_pricing=candidate.tiered_pricing,
+            provider_input_price=candidate.input_price,
+            provider_output_price=candidate.output_price,
+        )
+
+        # Calculate cost (only input cost, as we're selecting before making the request)
+        cost_breakdown = calculate_cost_from_billing(
+            input_tokens=input_tokens,
+            output_tokens=0,  # We don't know output tokens yet
+            billing=billing,
+        )
+
+        # For per_request billing, use the full per_request_price as the cost
+        # For token-based billing, use only the input_cost
+        return cost_breakdown.total_cost if billing.billing_mode == "per_request" else cost_breakdown.input_cost
+
+    async def select(
+        self,
+        candidates: list[CandidateProvider],
+        requested_model: str,
+        input_tokens: Optional[int] = None,
+    ) -> Optional[CandidateProvider]:
+        """
+        Select provider with lowest cost
+
+        Args:
+            candidates: List of candidate providers
+            requested_model: Requested model name
+            input_tokens: Number of input tokens
+
+        Returns:
+            Optional[CandidateProvider]: Provider with lowest cost, or None if no providers available
+        """
+        if not candidates:
+            return None
+
+        # If no input_tokens provided, fall back to first candidate (by priority)
+        if input_tokens is None or input_tokens == 0:
+            logger.warning("CostFirstStrategy: No input_tokens provided, falling back to first candidate")
+            return candidates[0]
+
+        # Calculate cost for each candidate
+        candidates_with_cost = []
+        for candidate in candidates:
+            try:
+                cost = self._calculate_input_cost(candidate, input_tokens)
+                candidates_with_cost.append((candidate, cost))
+                logger.debug(
+                    f"CostFirstStrategy: Provider {candidate.provider_name} (ID: {candidate.provider_id}) "
+                    f"estimated input cost: ${cost:.6f} for {input_tokens} input tokens"
+                )
+            except Exception as e:
+                logger.error(
+                    f"CostFirstStrategy: Error calculating cost for provider {candidate.provider_name} "
+                    f"(ID: {candidate.provider_id}): {e}"
+                )
+                # Assign a high cost to providers with calculation errors
+                # so they're deprioritized but not excluded
+                candidates_with_cost.append((candidate, float('inf')))
+
+        # Sort by cost (lowest first), then by priority, then by provider_id
+        candidates_with_cost.sort(key=lambda x: (x[1], x[0].priority, x[0].provider_id))
+
+        selected = candidates_with_cost[0][0]
+        selected_cost = candidates_with_cost[0][1]
+
+        logger.info(
+            f"CostFirstStrategy: Selected provider {selected.provider_name} (ID: {selected.provider_id}) "
+            f"with estimated input cost ${selected_cost:.6f}"
+        )
+
+        return selected
+
+    async def get_next(
+        self,
+        candidates: list[CandidateProvider],
+        requested_model: str,
+        current: CandidateProvider,
+        input_tokens: Optional[int] = None,
+    ) -> Optional[CandidateProvider]:
+        """
+        Get next provider by cost (used for failover)
+
+        Args:
+            candidates: List of candidate providers
+            requested_model: Requested model name
+            current: Current provider
+            input_tokens: Number of input tokens
+
+        Returns:
+            Optional[CandidateProvider]: Next cheapest provider, or None if no more providers
+        """
+        if not candidates or len(candidates) <= 1:
+            return None
+
+        # If no input_tokens provided, fall back to simple next-in-list logic
+        if input_tokens is None or input_tokens == 0:
+            # Find index of current provider
+            current_index = -1
+            for i, c in enumerate(candidates):
+                if c.provider_id == current.provider_id:
+                    current_index = i
+                    break
+
+            if current_index == -1:
+                return None
+
+            next_index = (current_index + 1) % len(candidates)
+            if next_index == current_index:
+                return None
+
+            return candidates[next_index]
+
+        # Re-sort candidates by cost to find the next cheapest option
+        candidates_with_cost = []
+        for candidate in candidates:
+            try:
+                cost = self._calculate_input_cost(candidate, input_tokens)
+                candidates_with_cost.append((candidate, cost))
+            except Exception as e:
+                logger.error(
+                    f"CostFirstStrategy.get_next: Error calculating cost for provider "
+                    f"{candidate.provider_name} (ID: {candidate.provider_id}): {e}"
+                )
+                candidates_with_cost.append((candidate, float('inf')))
+
+        # Sort by cost, then priority, then provider_id
+        candidates_with_cost.sort(key=lambda x: (x[1], x[0].priority, x[0].provider_id))
+
+        # Find current provider in the sorted list
+        current_index = -1
+        for i, (c, _) in enumerate(candidates_with_cost):
+            if c.provider_id == current.provider_id:
+                current_index = i
+                break
+
+        if current_index == -1:
+            return None
+
+        # Return next provider in the sorted list
+        next_index = current_index + 1
+        if next_index >= len(candidates_with_cost):
+            return None
+
+        next_candidate = candidates_with_cost[next_index][0]
+        next_cost = candidates_with_cost[next_index][1]
+
+        logger.info(
+            f"CostFirstStrategy: Failover to provider {next_candidate.provider_name} "
+            f"(ID: {next_candidate.provider_id}) with estimated input cost ${next_cost:.6f}"
+        )
+
+        return next_candidate

--- a/backend/tests/unit/test_services/test_strategy.py
+++ b/backend/tests/unit/test_services/test_strategy.py
@@ -4,7 +4,7 @@ Round Robin Strategy Unit Tests
 
 import pytest
 import asyncio
-from app.services.strategy import RoundRobinStrategy
+from app.services.strategy import RoundRobinStrategy, CostFirstStrategy
 from app.rules.models import CandidateProvider
 
 
@@ -132,3 +132,162 @@ class TestRoundRobinStrategy:
         # Each provider should be selected roughly 33 times
         for provider_id, count in counts.items():
             assert 20 <= count <= 50, f"Provider {provider_id} selected {count} times"
+
+
+class TestCostFirstStrategy:
+    """Cost First Strategy Tests"""
+
+    def setup_method(self):
+        """Setup before test"""
+        self.strategy = CostFirstStrategy()
+        # Create candidates with different pricing
+        self.candidates = [
+            CandidateProvider(
+                provider_id=1,
+                provider_name="ExpensiveProvider",
+                base_url="https://api1.com",
+                protocol="openai",
+                api_key="key1",
+                target_model="model1",
+                priority=1,
+                billing_mode="token_flat",
+                input_price=10.0,  # $10 per 1M tokens
+                output_price=30.0,
+                model_input_price=5.0,
+                model_output_price=15.0,
+            ),
+            CandidateProvider(
+                provider_id=2,
+                provider_name="CheapProvider",
+                base_url="https://api2.com",
+                protocol="openai",
+                api_key="key2",
+                target_model="model2",
+                priority=2,
+                billing_mode="token_flat",
+                input_price=1.0,  # $1 per 1M tokens
+                output_price=3.0,
+                model_input_price=5.0,
+                model_output_price=15.0,
+            ),
+            CandidateProvider(
+                provider_id=3,
+                provider_name="MediumProvider",
+                base_url="https://api3.com",
+                protocol="openai",
+                api_key="key3",
+                target_model="model3",
+                priority=3,
+                billing_mode="token_flat",
+                input_price=5.0,  # $5 per 1M tokens
+                output_price=15.0,
+                model_input_price=5.0,
+                model_output_price=15.0,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_select_lowest_cost(self):
+        """Test that the lowest cost provider is selected"""
+        # With 1000 input tokens
+        selected = await self.strategy.select(self.candidates, "test-model", input_tokens=1000)
+        # Should select provider 2 (CheapProvider) with $1/1M = $0.001 for 1000 tokens
+        assert selected.provider_id == 2
+        assert selected.provider_name == "CheapProvider"
+
+    @pytest.mark.asyncio
+    async def test_select_with_per_request_billing(self):
+        """Test cost selection with per-request billing"""
+        candidates_with_per_request = [
+            CandidateProvider(
+                provider_id=1,
+                provider_name="TokenBased",
+                base_url="https://api1.com",
+                protocol="openai",
+                api_key="key1",
+                target_model="model1",
+                priority=1,
+                billing_mode="token_flat",
+                input_price=5.0,
+                output_price=15.0,
+                model_input_price=5.0,
+                model_output_price=15.0,
+            ),
+            CandidateProvider(
+                provider_id=2,
+                provider_name="PerRequest",
+                base_url="https://api2.com",
+                protocol="openai",
+                api_key="key2",
+                target_model="model2",
+                priority=2,
+                billing_mode="per_request",
+                per_request_price=0.001,  # $0.001 per request
+                model_input_price=5.0,
+                model_output_price=15.0,
+            ),
+        ]
+
+        # With 1000 input tokens, token-based: 1000/1M * $5 = $0.005
+        # Per-request: $0.001
+        # Per-request should be selected
+        selected = await self.strategy.select(candidates_with_per_request, "test-model", input_tokens=1000)
+        assert selected.provider_id == 2
+        assert selected.provider_name == "PerRequest"
+
+    @pytest.mark.asyncio
+    async def test_get_next_by_cost(self):
+        """Test that get_next returns the next cheapest provider"""
+        current = self.candidates[1]  # CheapProvider (ID: 2)
+        next_provider = await self.strategy.get_next(
+            self.candidates, "test-model", current, input_tokens=1000
+        )
+        # Next cheapest should be MediumProvider (ID: 3)
+        assert next_provider.provider_id == 3
+        assert next_provider.provider_name == "MediumProvider"
+
+        # After medium, should be expensive
+        current = self.candidates[2]  # MediumProvider (ID: 3)
+        next_provider = await self.strategy.get_next(
+            self.candidates, "test-model", current, input_tokens=1000
+        )
+        assert next_provider.provider_id == 1
+        assert next_provider.provider_name == "ExpensiveProvider"
+
+    @pytest.mark.asyncio
+    async def test_select_no_input_tokens(self):
+        """Test selection without input tokens falls back to first candidate"""
+        selected = await self.strategy.select(self.candidates, "test-model", input_tokens=None)
+        # Should fall back to first candidate (by priority)
+        assert selected.provider_id == 1
+
+    @pytest.mark.asyncio
+    async def test_select_empty_candidates(self):
+        """Test empty candidate list"""
+        selected = await self.strategy.select([], "test-model", input_tokens=1000)
+        assert selected is None
+
+    @pytest.mark.asyncio
+    async def test_get_next_no_more_providers(self):
+        """Test get_next when already at the last (most expensive) provider"""
+        current = self.candidates[0]  # ExpensiveProvider (ID: 1)
+        # After the most expensive, there should be no next
+        next_provider = await self.strategy.get_next(
+            self.candidates, "test-model", current, input_tokens=1000
+        )
+        # get_next should return None when at the end
+        assert next_provider is None
+
+    @pytest.mark.asyncio
+    async def test_cost_calculation_with_different_token_counts(self):
+        """Test that cost is recalculated based on actual input tokens"""
+        # With 100 tokens, all should be very cheap
+        selected = await self.strategy.select(self.candidates, "test-model", input_tokens=100)
+        assert selected.provider_id == 2  # Still cheapest
+
+        # With 1M tokens, cost differences should be significant
+        selected = await self.strategy.select(self.candidates, "test-model", input_tokens=1000000)
+        assert selected.provider_id == 2  # Still cheapest
+        # Provider 2: $1 * 1M/1M = $1.00
+        # Provider 3: $5 * 1M/1M = $5.00
+        # Provider 1: $10 * 1M/1M = $10.00


### PR DESCRIPTION
Implements a new "Cost First" selection method that prioritizes cost efficiency when forwarding requests to providers. The strategy:

1. Calculates input costs for all matched providers based on their billing configuration (token-based, tiered, or per-request)
2. Selects the provider with the lowest estimated cost
3. Falls back to progressively more expensive providers on failure
4. Supports all three billing modes: token_flat, token_tiered, and per_request

Changes:
- Extended CandidateProvider with billing fields (billing_mode, input_price, output_price, per_request_price, tiered_pricing, model_input_price, model_output_price)
- Updated rule engine to populate billing info when creating candidates
- Added CostFirstStrategy class implementing cost-based selection logic
- Extended SelectionStrategy interface to accept input_tokens parameter
- Updated RetryHandler to pass input_tokens to strategy methods
- Modified ProxyService to pass input_tokens to retry handler
- Added comprehensive unit tests for CostFirstStrategy

The implementation maintains backward compatibility with existing RoundRobinStrategy and allows users to choose between different selection strategies.