### PR TITLE
claude/add cost first selection 0zGU3

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -25,7 +25,6 @@ from app.services import (
     ApiKeyService,
     LogService,
     ProxyService,
-    RoundRobinStrategy,
 )
 
 
@@ -42,12 +41,6 @@ async def get_db():
 
 # Database session dependency type
 DbSession = Annotated[AsyncSession, Depends(get_db)]
-
-
-# ============ Global Singleton ============
-
-# Global strategy instance, ensures round-robin state is maintained across requests
-_global_strategy = RoundRobinStrategy()
 
 
 # ============ Repository Dependencies ============
@@ -104,7 +97,7 @@ def get_proxy_service(db: DbSession) -> ProxyService:
     model_repo = SQLAlchemyModelRepository(db)
     provider_repo = SQLAlchemyProviderRepository(db)
     log_repo = SQLAlchemyLogRepository(db)
-    return ProxyService(model_repo, provider_repo, log_repo, strategy=_global_strategy)
+    return ProxyService(model_repo, provider_repo, log_repo)
 
 
 # ============ Auth Dependencies ============

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -84,7 +84,7 @@ class ModelMapping(Base):
     requested_model: Mapped[str] = mapped_column(
         String(100), primary_key=True, nullable=False
     )
-    # Selection strategy, currently only supports round_robin
+    # Selection strategy: round_robin or cost_first
     strategy: Mapped[str] = mapped_column(String(50), default="round_robin")
     # Model-level matching rules (JSON format)
     matching_rules: Mapped[Optional[dict]] = mapped_column(SQLiteJSON, nullable=True)

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -12,6 +12,7 @@ from typing_extensions import Literal
 
 
 BillingMode = Literal["token_flat", "token_tiered", "per_request"]
+SelectionStrategyType = Literal["round_robin", "cost_first"]
 
 
 class TokenTierPrice(BaseModel):
@@ -28,13 +29,13 @@ class TokenTierPrice(BaseModel):
 
 class ModelMappingBase(BaseModel):
     """Model Mapping Base Model"""
-    
+
     # Requested Model Name (Primary Key)
     requested_model: str = Field(
         ..., min_length=1, max_length=100, description="Requested Model Name"
     )
-    # Selection Strategy, currently only supports round_robin
-    strategy: str = Field("round_robin", description="Selection Strategy")
+    # Selection Strategy: round_robin or cost_first
+    strategy: SelectionStrategyType = Field("round_robin", description="Selection Strategy")
 
 
 class ModelMappingCreate(ModelMappingBase):
@@ -53,8 +54,8 @@ class ModelMappingCreate(ModelMappingBase):
 
 class ModelMappingUpdate(BaseModel):
     """Update Model Mapping Request Model"""
-    
-    strategy: Optional[str] = None
+
+    strategy: Optional[SelectionStrategyType] = None
     matching_rules: Optional[dict[str, Any]] = None
     capabilities: Optional[dict[str, Any]] = None
     is_active: Optional[bool] = None

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -18,6 +18,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { RuleBuilder } from '@/components/common';
 import { ModelMapping, ModelMappingCreate, ModelMappingUpdate, RuleSet } from '@/types';
 import { isValidModelName } from '@/lib/utils';
@@ -224,15 +231,41 @@ export function ModelForm({
 
           {/* Strategy */}
           <div className="space-y-2">
-            <Label htmlFor="strategy">Select Strategy</Label>
-            <Input
-              id="strategy"
-              value="round_robin"
-              disabled
-              {...register('strategy')}
+            <Label htmlFor="strategy">Selection Strategy</Label>
+            <Controller
+              name="strategy"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger id="strategy">
+                    <SelectValue placeholder="Select strategy" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="round_robin">
+                      <div className="flex flex-col">
+                        <span className="font-medium">Round Robin</span>
+                        <span className="text-xs text-muted-foreground">
+                          Distribute requests evenly across providers
+                        </span>
+                      </div>
+                    </SelectItem>
+                    <SelectItem value="cost_first">
+                      <div className="flex flex-col">
+                        <span className="font-medium">Cost First</span>
+                        <span className="text-xs text-muted-foreground">
+                          Prioritize lowest-cost providers based on input tokens
+                        </span>
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
             />
             <p className="text-sm text-muted-foreground">
-              Currently only supports Round Robin strategy (round_robin)
+              Round Robin: Evenly distributes requests. Cost First: Selects provider with lowest estimated cost.
             </p>
           </div>
 

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -26,7 +26,13 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { RuleBuilder } from '@/components/common';
-import { ModelMapping, ModelMappingCreate, ModelMappingUpdate, RuleSet } from '@/types';
+import {
+  ModelMapping,
+  ModelMappingCreate,
+  ModelMappingUpdate,
+  RuleSet,
+  SelectionStrategy
+} from '@/types';
 import { isValidModelName } from '@/lib/utils';
 
 interface ModelFormProps {
@@ -45,7 +51,7 @@ interface ModelFormProps {
 /** Form Field Definition */
 interface FormData {
   requested_model: string;
-  strategy: string;
+  strategy: SelectionStrategy;
   matching_rules: RuleSet | null;
   is_active: boolean;
   input_price: string;

--- a/frontend/src/components/models/ModelList.tsx
+++ b/frontend/src/components/models/ModelList.tsx
@@ -59,7 +59,9 @@ export function ModelList({
                 {model.requested_model}
               </TableCell>
               <TableCell>
-                <Badge variant="outline">{model.strategy}</Badge>
+                <Badge variant="outline">
+                  {model.strategy === 'cost_first' ? 'Cost First' : 'Round Robin'}
+                </Badge>
               </TableCell>
               <TableCell>
                 <Badge variant="secondary">{model.provider_count || 0}</Badge>

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -6,10 +6,13 @@
 import { RuleSet } from './common';
 import { ProtocolType } from './provider';
 
+/** Selection Strategy Type */
+export type SelectionStrategy = 'round_robin' | 'cost_first';
+
 /** Model Mapping Entity */
 export interface ModelMapping {
   requested_model: string;            // Primary Key
-  strategy: string;                   // Strategy, default round_robin
+  strategy: SelectionStrategy;        // Selection strategy
   matching_rules?: RuleSet | null;    // Model level rules
   capabilities?: Record<string, unknown>; // Capabilities description
   is_active: boolean;
@@ -54,7 +57,7 @@ export interface ModelMappingProvider {
 /** Create Model Mapping Request */
 export interface ModelMappingCreate {
   requested_model: string;
-  strategy?: string;
+  strategy?: SelectionStrategy;
   matching_rules?: RuleSet;
   capabilities?: Record<string, unknown>;
   is_active?: boolean;
@@ -64,7 +67,7 @@ export interface ModelMappingCreate {
 
 /** Update Model Mapping Request */
 export interface ModelMappingUpdate {
-  strategy?: string;
+  strategy?: SelectionStrategy;
   matching_rules?: RuleSet | null;
   capabilities?: Record<string, unknown>;
   is_active?: boolean;


### PR DESCRIPTION
- **Implemented OpenAI ↔ Anthropic protocol conversion (via `litellm`, assumed to be the intended “LightLML”) based on the selected supplier’s `protocol`, converting request/response (including SSE streaming) when they differ.**
- **Fix LiteLLM experimental passthrough import fallback (vibe-kanban d142)**
- **debug for 协议转换 (vibe-kanban a8eb28ed)**
- **Anthropic 400 Error (vibe-kanban 89f7de79)**
- **相同协议的情况下，响应内容透传 (vibe-kanban e0653696)**
- **支持设置额外的请求头 (vibe-kanban 2ca0fac6)**
- **统一日志格式 (vibe-kanban 0208eb6b)**
- **统一日志格式 (vibe-kanban 0208eb6b)**
- **增加后台登录鉴权功能 (vibe-kanban 4e3c6acf)**
- **update**
- **Translate to english (vibe-kanban 88497c94)**
- **Translate to english (vibe-kanban 88497c94)**
- **Translate to english (vibe-kanban 88497c94)**
- **Translate to english (vibe-kanban 88497c94)**
- **日志列表时间展示优化 (vibe-kanban d376decf)**
- **请求日志页面 bug (vibe-kanban 68a88903)**
- **后端服务启动报错了 (vibe-kanban ce370dc7)**
- **弹窗显示效果优化 (vibe-kanban e255e571)**
- **弹窗显示效果优化 (vibe-kanban e255e571)**
- **详情查看页面样式优化 (vibe-kanban 69df524b)**
- **详情查看页面样式优化 (vibe-kanban 69df524b)**
- **bug：前端页面报错 (vibe-kanban e4560ff9)**
- **处理请求的时候报错了 (vibe-kanban 3df81bea)**
- **日志搜索页面优化 (vibe-kanban be46b48d)**
- **工具调用能力缺失 (vibe-kanban dd6597a0)**
- **update**
- **部署准备 (vibe-kanban 384e1b34)**
- **创建一键启动脚本 (vibe-kanban 253e856c)**
- **创建一键启动脚本 (vibe-kanban 253e856c)**
- **bugfix: save model failed (vibe-kanban d00bdfcb)**
- **支持模型 & 供应商数据导入导出 (vibe-kanban 61b194df)**
- **黑暗模式 (vibe-kanban 1ef0c238)**
- **update**
- **优化弹窗显示效果 (vibe-kanban bf5efef7)**
- **对话框弹出效果优化 (vibe-kanban 631459c6)**
- **当修改数据成功时（比如新增、保存、删除等操作），应该在页面右上角展示成功的提示信息。该提示需具备以下功能： (vibe-kanban 27a3ea66)**
- **新增模型费用能力 (vibe-kanban b893848b)**
- **新增模型费用能力 (vibe-kanban b893848b)**
- **新增模型费用能力 (vibe-kanban b893848b)**
- **新增模型费用能力 (vibe-kanban b893848b)**
- **新增模型费用能力 (vibe-kanban b893848b)**
- **新增模型费用能力 (vibe-kanban b893848b)**
- **remove Capabilities Description (vibe-kanban d8f5b97d)**
- **update**
- **侧边栏优化 (vibe-kanban 1dadda0d)**
- **Cost Stats 优化 (vibe-kanban b6238652)**
- **Cost Stats 优化 (vibe-kanban b6238652)**
- **Cost Stats 优化 (vibe-kanban b6238652)**
- **Cost Stats 优化 (vibe-kanban b6238652)**
- **update**
- **首页 Activity 卡片优化 (vibe-kanban 12abb941)**
- **update**
- **update**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **增加更多的统计图表 (vibe-kanban e34d8da1)**
- **Docker 环境无法访问首页 (vibe-kanban fddfcedf)**
- **update**
- **同一时区 (vibe-kanban af5e092f)**
- **同一时区 (vibe-kanban af5e092f)**
- **同一时区 (vibe-kanban af5e092f)**
- **update**
- **update**
- **update**
- **bug for activity api (vibe-kanban a728b241)**
- **Provider Request Header missing (vibe-kanban 362ded2e)**
- **add support for /v1/responses (vibe-kanban df6a2b2e)**
- **删除 provider 报错 (vibe-kanban 2b8c11cf)**
- **删除 provider 报错 (vibe-kanban 2b8c11cf)**
- **删除 provider 报错 (vibe-kanban 2b8c11cf)**
- **update**
- **日志列表优化 (vibe-kanban 3ea9677b)**
- **Nginx 反向代理错误 (vibe-kanban f05f1397)**
- **Activity 卡片优化 (vibe-kanban 1665ca31)**
- **update**
- **支持模型按次计费 (vibe-kanban 29bc513e)**
- **支持模型按次计费 (vibe-kanban 29bc513e)**
- **update**
- **非 Stream 请求 输出 Token 计数为 0 (vibe-kanban 72ff18f1)**
- **Add Cost First provider selection strategy**
- **Enable per-model strategy selection with Cost First support**
- **Improve type safety and UI for Cost First strategy**
