### PR TITLE
Remove duplicate matching rules from model config

### DIFF
--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -40,9 +40,7 @@ class ModelMappingBase(BaseModel):
 
 class ModelMappingCreate(ModelMappingBase):
     """Create Model Mapping Request Model"""
-    
-    # Model Level Matching Rules
-    matching_rules: Optional[dict[str, Any]] = Field(None, description="Matching Rules")
+
     # Model Capabilities Description
     capabilities: Optional[dict[str, Any]] = Field(None, description="Model Capabilities")
     # Is Active
@@ -56,7 +54,6 @@ class ModelMappingUpdate(BaseModel):
     """Update Model Mapping Request Model"""
 
     strategy: Optional[SelectionStrategyType] = None
-    matching_rules: Optional[dict[str, Any]] = None
     capabilities: Optional[dict[str, Any]] = None
     is_active: Optional[bool] = None
     input_price: Optional[float] = None
@@ -65,15 +62,14 @@ class ModelMappingUpdate(BaseModel):
 
 class ModelMapping(ModelMappingBase):
     """Model Mapping Complete Model"""
-    
-    matching_rules: Optional[dict[str, Any]] = None
+
     capabilities: Optional[dict[str, Any]] = None
     is_active: bool = True
     input_price: Optional[float] = None
     output_price: Optional[float] = None
     created_at: datetime
     updated_at: datetime
-    
+
     class Config:
         from_attributes = True
 

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -340,7 +340,6 @@ class ModelService:
                 ModelExport(
                     requested_model=m.requested_model,
                     strategy=m.strategy,
-                    matching_rules=m.matching_rules,
                     capabilities=m.capabilities,
                     is_active=m.is_active,
                     input_price=m.input_price,
@@ -445,7 +444,6 @@ class ModelService:
         return ModelMappingResponse(
             requested_model=mapping.requested_model,
             strategy=mapping.strategy,
-            matching_rules=mapping.matching_rules,
             capabilities=mapping.capabilities,
             is_active=mapping.is_active,
             input_price=mapping.input_price,

--- a/frontend/src/app/models/detail/page.tsx
+++ b/frontend/src/app/models/detail/page.tsx
@@ -228,17 +228,6 @@ function ModelDetailContent() {
         </CardContent>
       </Card>
 
-      {model.matching_rules && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Matching Rules</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <JsonViewer data={model.matching_rules} />
-          </CardContent>
-        </Card>
-      )}
-
       {/* {model.capabilities && (
         <Card>
           <CardHeader>

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -25,12 +25,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { RuleBuilder } from '@/components/common';
 import {
   ModelMapping,
   ModelMappingCreate,
   ModelMappingUpdate,
-  RuleSet,
   SelectionStrategy
 } from '@/types';
 import { isValidModelName } from '@/lib/utils';
@@ -52,7 +50,6 @@ interface ModelFormProps {
 interface FormData {
   requested_model: string;
   strategy: SelectionStrategy;
-  matching_rules: RuleSet | null;
   is_active: boolean;
   input_price: string;
   output_price: string;
@@ -84,7 +81,6 @@ export function ModelForm({
     defaultValues: {
       requested_model: '',
       strategy: 'round_robin',
-      matching_rules: null,
       is_active: true,
       input_price: '',
       output_price: '',
@@ -99,7 +95,6 @@ export function ModelForm({
       reset({
         requested_model: model.requested_model,
         strategy: model.strategy,
-        matching_rules: model.matching_rules || null,
         is_active: model.is_active,
         input_price:
           model.input_price === null || model.input_price === undefined
@@ -114,7 +109,6 @@ export function ModelForm({
       reset({
         requested_model: '',
         strategy: 'round_robin',
-        matching_rules: null,
         is_active: true,
         input_price: '',
         output_price: '',
@@ -128,14 +122,11 @@ export function ModelForm({
       strategy: data.strategy,
       is_active: data.is_active,
     };
-    
+
     // requested_model required on creation
     if (!isEdit) {
       (submitData as ModelMappingCreate).requested_model = data.requested_model;
     }
-    
-    // Assign rules directly
-    submitData.matching_rules = data.matching_rules || undefined;
 
     // Preserve existing capabilities on edit (field hidden in UI)
     if (isEdit && model?.capabilities) {
@@ -146,7 +137,7 @@ export function ModelForm({
     const outputPrice = data.output_price.trim();
     submitData.input_price = inputPrice ? Number(inputPrice) : null;
     submitData.output_price = outputPrice ? Number(outputPrice) : null;
-    
+
     onSubmit(submitData);
   };
 
@@ -218,21 +209,6 @@ export function ModelForm({
             <p className="mt-2 text-xs text-muted-foreground">
               Used as model fallback price when no provider override exists; empty means unconfigured.
             </p>
-          </div>
-
-          {/* Matching Rules */}
-          <div className="space-y-2">
-            <Label>Matching Rules (Beta)</Label>
-            <Controller
-              name="matching_rules"
-              control={control}
-              render={({ field }) => (
-                <RuleBuilder
-                  value={field.value || undefined}
-                  onChange={field.onChange}
-                />
-              )}
-            />
           </div>
 
           {/* Strategy */}

--- a/frontend/src/components/models/ModelList.tsx
+++ b/frontend/src/components/models/ModelList.tsx
@@ -44,7 +44,6 @@ export function ModelList({
           <TableHead>Requested Model Name</TableHead>
           <TableHead>Strategy</TableHead>
           <TableHead>Provider Count</TableHead>
-          <TableHead>Matching Rules</TableHead>
           <TableHead>Status</TableHead>
           <TableHead>Updated At</TableHead>
           <TableHead className="text-right">Actions</TableHead>
@@ -65,15 +64,6 @@ export function ModelList({
               </TableCell>
               <TableCell>
                 <Badge variant="secondary">{model.provider_count || 0}</Badge>
-              </TableCell>
-              <TableCell>
-                {model.matching_rules ? (
-                  <Badge variant="outline" className="text-blue-600">
-                    Configured
-                  </Badge>
-                ) : (
-                  <span className="text-muted-foreground">-</span>
-                )}
               </TableCell>
               <TableCell>
                 <Badge className={status.className}>{status.text}</Badge>

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -13,7 +13,6 @@ export type SelectionStrategy = 'round_robin' | 'cost_first';
 export interface ModelMapping {
   requested_model: string;            // Primary Key
   strategy: SelectionStrategy;        // Selection strategy
-  matching_rules?: RuleSet | null;    // Model level rules
   capabilities?: Record<string, unknown>; // Capabilities description
   is_active: boolean;
   // Pricing (USD per 1,000,000 tokens)
@@ -58,7 +57,6 @@ export interface ModelMappingProvider {
 export interface ModelMappingCreate {
   requested_model: string;
   strategy?: SelectionStrategy;
-  matching_rules?: RuleSet;
   capabilities?: Record<string, unknown>;
   is_active?: boolean;
   input_price?: number | null;
@@ -68,7 +66,6 @@ export interface ModelMappingCreate {
 /** Update Model Mapping Request */
 export interface ModelMappingUpdate {
   strategy?: SelectionStrategy;
-  matching_rules?: RuleSet | null;
   capabilities?: Record<string, unknown>;
   is_active?: boolean;
   input_price?: number | null;


### PR DESCRIPTION
This change simplifies the matching rules architecture by:

1. Removing matching_rules from Model configuration:
   - Removed from ModelMappingCreate, ModelMappingUpdate, ModelMapping DTOs
   - Removed from model_service.py export/response functions
   - Removed from frontend ModelForm.tsx, ModelList.tsx, detail page

2. Updated RuleEngine to only use provider-level rules:
   - Removed model-level rule checking from evaluate() and evaluate_sync()
   - Provider rules now serve as the single point of rule configuration
   - Empty/null provider_rules still defaults to matching all requests

3. Added comprehensive unit tests for provider-level rules:
   - Tests for AND/OR logic
   - Tests for various operators (eq, contains, in, regex, etc.)
   - Tests for edge cases (all providers fail, inactive mappings, etc.)

The workflow now is:
1. API request comes in with a model name
2. Find all provider bindings for that model
3. For each provider binding, check its provider_rules:
   - If rules match -> provider is available
   - If rules don't match -> skip the provider
   - If no rules configured -> provider matches by default
4. Apply selection strategy (round_robin/cost_first) to matched providers

Note: The database column model_mappings.matching_rules is kept for backward compatibility but is no longer used.