### PR TITLE
feat: 增强请求日志记录，添加协议转换数据跟踪

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -270,7 +270,16 @@ class RequestLog(Base):
     trace_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     # Is Stream Request
     is_stream: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    
+    # Protocol Conversion Fields (for debugging and analysis)
+    # Client request protocol (openai/anthropic)
+    request_protocol: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    # Upstream supplier protocol (openai/anthropic)
+    supplier_protocol: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    # Converted request body (sent to upstream after protocol conversion)
+    converted_request_body: Mapped[Optional[dict]] = mapped_column(SQLiteJSON, nullable=True)
+    # Upstream response body (original response before protocol conversion)
+    upstream_response_body: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
     # Indices for optimizing queries
     __table_args__ = (
         Index("idx_request_logs_time", "request_time"),

--- a/backend/app/domain/log.py
+++ b/backend/app/domain/log.py
@@ -40,7 +40,7 @@ class RequestLogBase(BaseModel):
 
 class RequestLogCreate(RequestLogBase):
     """Create Request Log Model"""
-    
+
     # Retry Count
     retry_count: int = Field(0, description="Retry Count")
     # First Byte Delay (ms)
@@ -73,6 +73,19 @@ class RequestLogCreate(RequestLogBase):
     trace_id: Optional[str] = Field(None, description="Trace ID")
     # Is Stream Request
     is_stream: bool = Field(False, description="Is Stream Request")
+    # Protocol Conversion Fields (for debugging and analysis)
+    # Client request protocol (openai/anthropic)
+    request_protocol: Optional[str] = Field(None, description="Client Request Protocol")
+    # Upstream supplier protocol (openai/anthropic)
+    supplier_protocol: Optional[str] = Field(None, description="Upstream Supplier Protocol")
+    # Converted request body (sent to upstream after protocol conversion)
+    converted_request_body: Optional[dict[str, Any]] = Field(
+        None, description="Converted Request Body (after protocol conversion)"
+    )
+    # Upstream response body (original response before protocol conversion)
+    upstream_response_body: Optional[str] = Field(
+        None, description="Upstream Response Body (before protocol conversion)"
+    )
 
 
 class RequestLogModel(RequestLogCreate):

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -19,3 +19,9 @@ psql -U username -d database_name -f migrations/add_is_stream_column.sql
 ## Migration Files
 
 - `add_is_stream_column.sql` - Adds the `is_stream` boolean field to the `request_logs` table to indicate whether a request is a stream request.
+- `add_extra_headers_column.sql` - Adds the `extra_headers` JSON field to the `service_providers` table for custom headers.
+- `add_protocol_conversion_columns.sql` - Adds protocol conversion tracking columns to `request_logs` for debugging and analysis:
+  - `request_protocol` - Client request protocol (openai/anthropic)
+  - `supplier_protocol` - Upstream supplier protocol (openai/anthropic)
+  - `converted_request_body` - Request body after protocol conversion
+  - `upstream_response_body` - Original upstream response before protocol conversion

--- a/backend/migrations/add_protocol_conversion_columns.sql
+++ b/backend/migrations/add_protocol_conversion_columns.sql
@@ -1,0 +1,15 @@
+-- Add protocol conversion columns to request_logs table
+-- These columns store converted request/response data for debugging and analysis
+-- Run this migration if you have an existing database
+
+-- For SQLite
+ALTER TABLE request_logs ADD COLUMN request_protocol VARCHAR(50) DEFAULT NULL;
+ALTER TABLE request_logs ADD COLUMN supplier_protocol VARCHAR(50) DEFAULT NULL;
+ALTER TABLE request_logs ADD COLUMN converted_request_body JSON DEFAULT NULL;
+ALTER TABLE request_logs ADD COLUMN upstream_response_body TEXT DEFAULT NULL;
+
+-- For PostgreSQL (uncomment if using PostgreSQL)
+-- ALTER TABLE request_logs ADD COLUMN request_protocol VARCHAR(50) DEFAULT NULL;
+-- ALTER TABLE request_logs ADD COLUMN supplier_protocol VARCHAR(50) DEFAULT NULL;
+-- ALTER TABLE request_logs ADD COLUMN converted_request_body JSONB DEFAULT NULL;
+-- ALTER TABLE request_logs ADD COLUMN upstream_response_body TEXT DEFAULT NULL;


### PR DESCRIPTION
- 在请求日志中添加四个新字段用于记录协议转换信息:
  - request_protocol: 客户端请求使用的协议
  - supplier_protocol: 上游提供商使用的协议
  - converted_request_body: 协议转换后发送给上游的请求体
  - upstream_response_body: 上游返回的原始响应体(协议转换前)

- 更新的文件:
  - domain/log.py: 添加新字段定义
  - db/models.py: 添加数据库列定义
  - proxy_service.py: 在日志记录时捕获转换数据
  - migrations/: 添加数据库迁移脚本

这些新字段可以帮助在日志查看页面进行对比分析，方便调试协议转换问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced request logging to capture protocol conversion details including request protocol, supplier protocol, converted request data, and upstream response information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->