### PR TITLE
Make Docker host port configurable and fix CostStats props typing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ POSTGRES_PASSWORD=llm_gateway_password
 # ADMIN_USERNAME=admin
 # ADMIN_PASSWORD=change-me
 
+# Optional: host port for Docker Compose
+# LLM_GATEWAY_PORT=8000
+
 # If you want to use SQLite instead:
 # DATABASE_TYPE=sqlite
 # DATABASE_URL=sqlite+aiosqlite:////data/llm_gateway.db

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ cd llm-gateway
 
 # Configure environment
 cp .env.example .env
-# Edit .env if needed (optional: set ADMIN_USERNAME and ADMIN_PASSWORD)
+# Edit .env if needed (optional: set ADMIN_USERNAME, ADMIN_PASSWORD, LLM_GATEWAY_PORT)
 
 # Start services
 ./start-docker.sh
@@ -146,7 +146,7 @@ cp .env.example .env
 ./stop-docker.sh
 ```
 
-Access the dashboard at **http://localhost:8000**
+Access the dashboard at **http://localhost:8000** (or the port you set in `LLM_GATEWAY_PORT`)
 
 ### Docker (Single Container)
 
@@ -287,6 +287,7 @@ See [docs/api.md](docs/api.md) for complete API documentation.
 | `ADMIN_TOKEN_TTL_SECONDS` | 86400 | Admin session TTL (24 hours) |
 | `LOG_RETENTION_DAYS` | 7 | Log retention period |
 | `LOG_CLEANUP_HOUR` | 4 | Log cleanup time (UTC hour) |
+| `LLM_GATEWAY_PORT` | 8000 | Host port for Docker Compose |
 
 ### Database Configuration
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     image: llm-gateway:local
     ports:
-      - "8000:8000"
+      - "${LLM_GATEWAY_PORT:-8000}:8000"
     environment:
       DEBUG: ${DEBUG:-false}
       DATABASE_TYPE: ${DATABASE_TYPE:-sqlite}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "${LLM_GATEWAY_PORT:-8000}:8000"
     environment:
       DEBUG: ${DEBUG:-false}
       DATABASE_TYPE: ${DATABASE_TYPE:-postgresql}

--- a/frontend/src/components/logs/CostStats.tsx
+++ b/frontend/src/components/logs/CostStats.tsx
@@ -22,6 +22,7 @@ interface CostStatsProps {
   refreshing?: boolean;
   headerActions?: React.ReactNode;
   headerExtras?: React.ReactNode;
+  modelStatsControls?: React.ReactNode;
   rangeLabel?: string;
   rangeDays?: number;
   rangeStart?: string;

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -7,8 +7,6 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-RUNNING_URL="${SQUIRREL_RUNNING_URL:-http://127.0.0.1:8000}"
-
 # PostgreSQL image version (must match docker-compose.yml)
 PG_IMAGE="postgres:16-alpine"
 
@@ -77,6 +75,14 @@ EOF
 
 ensure_data_dir() {
   mkdir -p ./data
+}
+
+load_env() {
+  if [ -f ".env" ]; then
+    set -a
+    . ./.env
+    set +a
+  fi
 }
 
 # Wait for PostgreSQL container to be ready
@@ -296,11 +302,13 @@ cmd="${cmd:-up}"
 
 ensure_env
 ensure_data_dir
+load_env
 
 case "$cmd" in
   up)
     compose up -d --force-recreate --build $compose_args
     echo "Squirrel LLM Gateway is starting..."
+    RUNNING_URL="${SQUIRREL_RUNNING_URL:-http://127.0.0.1:${LLM_GATEWAY_PORT:-8000}}"
     echo "Dashboard/API: $RUNNING_URL"
 
     if [ "$SYNC_DB" = true ]; then


### PR DESCRIPTION
- Added LLM_GATEWAY_PORT support for Docker Compose (default 8000) and documented it in .env.example and  `README.md`.
- Updated `start-docker.sh` to display the effective dashboard/API port from .env.
- Fixed `CostStats` props typing to accept `modelStatsControls`, unblocking Next.js build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LLM_GATEWAY_PORT to allow customizing the gateway host port (default 8000) in Docker setups.
  * Cost stats component can now accept optional custom header controls for display.

* **Documentation**
  * Updated environment examples, README, and startup messaging to document the new port variable and show a dynamic Dashboard/API URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->