### PR TITLE
fix: properly handle multiple streaming tool calls without index field

### DIFF
--- a/llm_api_converter/api_protocol_converter/stream/__init__.py
+++ b/llm_api_converter/api_protocol_converter/stream/__init__.py
@@ -226,9 +226,10 @@ def convert_stream_sync(
     Yields:
         Converted events
     """
-    from ..converters import _DECODERS, _ENCODERS
+    from ..converters import _DECODER_CLASSES, _ENCODERS
 
-    decoder = _DECODERS[source_protocol]
+    # Create a fresh decoder instance per stream to isolate per-stream state
+    decoder = _DECODER_CLASSES[source_protocol]()
     encoder = _ENCODERS[target_protocol]
 
     for event in events:
@@ -261,8 +262,9 @@ class StreamConverter:
         self.accumulator = StreamAccumulator()
 
         # Import here to avoid circular imports
-        from ..converters import _DECODERS, _ENCODERS
-        self._decoder = _DECODERS[source_protocol]
+        from ..converters import _DECODER_CLASSES, _ENCODERS
+        # Create a fresh decoder instance per stream to isolate per-stream state
+        self._decoder = _DECODER_CLASSES[source_protocol]()
         self._encoder = _ENCODERS[target_protocol]
 
     def convert_event(

--- a/llm_api_converter/tests/fixtures.py
+++ b/llm_api_converter/tests/fixtures.py
@@ -586,6 +586,162 @@ OPENAI_RESPONSES_MULTIMODAL_REQUEST = {
     "max_output_tokens": 500,
 }
 
+# Streaming chunks: multiple tool calls WITHOUT index field (e.g., Google Gemini OpenAI-compat)
+OPENAI_CHAT_STREAM_MULTI_TOOL_NO_INDEX = [
+    # Chunk 1: role + first tool call (complete arguments in one chunk, no index field)
+    {
+        "id": "zCZ-aeCNCLDDjuMPrMTawQY",
+        "object": "chat.completion.chunk",
+        "created": 1769875148,
+        "model": "gemini-3-pro-preview",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "arguments": '{"path":"IDENTITY.md","content":"# Identity"}',
+                                "name": "write",
+                            },
+                            "id": "function-call-1111",
+                            "type": "function",
+                        }
+                    ],
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    # Chunk 2: second tool call (different id, no index field)
+    {
+        "id": "zCZ-aeCNCLDDjuMPrMTawQY",
+        "object": "chat.completion.chunk",
+        "created": 1769875149,
+        "model": "gemini-3-pro-preview",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "arguments": '{"path":"USER.md","content":"# User"}',
+                                "name": "write",
+                            },
+                            "id": "function-call-2222",
+                            "type": "function",
+                        }
+                    ],
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    # Chunk 3: finish
+    {
+        "id": "zCZ-aeCNCLDDjuMPrMTawQY",
+        "object": "chat.completion.chunk",
+        "created": 1769875149,
+        "model": "gemini-3-pro-preview",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant"},
+                "finish_reason": "stop",
+            }
+        ],
+    },
+]
+
+# Streaming chunks: standard OpenAI multi-tool with index fields
+OPENAI_CHAT_STREAM_MULTI_TOOL_WITH_INDEX = [
+    # Chunk 1: role + first tool call start
+    {
+        "id": "chatcmpl-toolstream",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_aaa",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"location":',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    # Chunk 2: first tool call arguments continuation
+    {
+        "id": "chatcmpl-toolstream",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '"Paris"}'},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    # Chunk 3: second tool call start
+    {
+        "id": "chatcmpl-toolstream",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 1,
+                            "id": "call_bbb",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"location":"London"}',
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    # Chunk 4: finish
+    {
+        "id": "chatcmpl-toolstream",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4o",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+    },
+]
+
 OPENAI_CHAT_WITH_BASE64_IMAGE_REQUEST = {
     "model": "gpt-4o",
     "messages": [


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g. Google Gemini) don't include the
`index` field in streaming tool_call objects. Previously, all such tool
calls defaulted to index 0, causing them to be merged into a single
Anthropic content block with concatenated JSON — producing invalid output.

Changes:
- Add per-stream state tracking to OpenAIChatDecoder to resolve tool call
  indices from their IDs when the index field is absent
- Emit CONTENT_BLOCK_STOP between tool calls and before MESSAGE_DELTA
- Deduplicate MESSAGE_START when multiple chunks contain the role field
- Create fresh decoder instances per stream (via _DECODER_CLASSES) to
  avoid shared mutable state across concurrent streams

https://claude.ai/code/session_01EQvjHfPLTLNjbE8Qmm7zmF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming state management to correctly handle multiple tool calls in a single stream.
  * Enhanced support for base64-encoded images in API requests.

* **Tests**
  * Added comprehensive test coverage for multi-tool streaming scenarios with and without explicit indexing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->