### PR TITLE
fix: 修复日志页面时间筛选输入框溢出导致布局错乱

### DIFF
--- a/frontend/src/components/logs/LogFilters.tsx
+++ b/frontend/src/components/logs/LogFilters.tsx
@@ -211,12 +211,12 @@ export function LogFilters({
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           <div className="space-y-2">
             <Label>{t('filters.startTime')}</Label>
-            <Input type="datetime-local" {...register('start_time')} />
+            <Input type="datetime-local" className="min-w-0" {...register('start_time')} />
           </div>
 
           <div className="space-y-2">
             <Label>{t('filters.endTime')}</Label>
-            <Input type="datetime-local" {...register('end_time')} />
+            <Input type="datetime-local" className="min-w-0" {...register('end_time')} />
           </div>
 
           <div className="space-y-2">


### PR DESCRIPTION
datetime-local 输入框有浏览器固有的最小宽度，在 grid 布局中会溢出单元格。
添加 min-w-0 使其能正确收缩适配网格列宽。

https://claude.ai/code/session_01XefQm1WHtYzpjY7zRnMJAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced datetime input field layout to ensure optimal sizing and improved visual consistency across the log filters interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->