### PR TITLE
feat(proxy): implement OpenAI and Anthropic protocol conversion

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -104,6 +104,11 @@ class ModelMapping(Base):
     # Default pricing (USD per 1,000,000 tokens)
     input_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
     output_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
+    # Model-level billing mode
+    billing_mode: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    per_request_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
+    per_image_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
+    tiered_pricing: Mapped[Optional[list]] = mapped_column(SQLiteJSON, nullable=True)
     # Is Active
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     # Creation Time
@@ -155,6 +160,10 @@ class ModelMappingProvider(Base):
     billing_mode: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     # Per-request fixed price (USD)
     per_request_price: Mapped[Optional[float]] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
+    # Per-image price (USD), used when billing_mode == per_image
+    per_image_price: Mapped[Optional[float]] = mapped_column(
         Numeric(12, 4), nullable=True
     )
     # Tiered pricing config (JSON). Used when billing_mode == "token_tiered"

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -103,6 +103,10 @@ def _run_migrations(sync_conn) -> None:
             "model_type": "model_type VARCHAR(50)",
             "input_price": "input_price NUMERIC(12,4)",
             "output_price": "output_price NUMERIC(12,4)",
+            "billing_mode": "billing_mode VARCHAR(50)",
+            "per_request_price": "per_request_price NUMERIC(12,4)",
+            "per_image_price": "per_image_price NUMERIC(12,4)",
+            "tiered_pricing": "tiered_pricing JSON",
         },
     )
     ensure_columns(
@@ -112,6 +116,7 @@ def _run_migrations(sync_conn) -> None:
             "output_price": "output_price NUMERIC(12,4)",
             "billing_mode": "billing_mode VARCHAR(50)",
             "per_request_price": "per_request_price NUMERIC(12,4)",
+            "per_image_price": "per_image_price NUMERIC(12,4)",
             "tiered_pricing": "tiered_pricing JSON",
         },
     )

--- a/backend/app/domain/api_key.py
+++ b/backend/app/domain/api_key.py
@@ -51,6 +51,8 @@ class ApiKeyResponse(ApiKeyBase):
     is_active: bool = Field(True, description="Is Active")
     created_at: datetime = Field(..., description="Creation Time")
     last_used_at: Optional[datetime] = Field(None, description="Last Used Time")
+    # Current month's total cost (USD)
+    monthly_cost: Optional[float] = Field(None, description="Current month's total cost (USD)")
     
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/domain/log.py
+++ b/backend/app/domain/log.py
@@ -135,10 +135,16 @@ class RequestLogDetailResponse(RequestLogModel):
 
 class RequestLogQuery(BaseModel):
     """Request Log Query Conditions"""
-    
+
     # Time Range
     start_time: Optional[datetime] = Field(None, description="Start Time")
     end_time: Optional[datetime] = Field(None, description="End Time")
+    # Relative time range preset (e.g. "24h"). Ignored when start_time is provided.
+    timeline: Optional[str] = Field(
+        None,
+        pattern="^(1h|3h|6h|12h|24h|1w)$",
+        description="Relative time range preset. Ignored when start_time is provided.",
+    )
     # Model Filter
     requested_model: Optional[str] = Field(None, description="Requested Model (Fuzzy Match)")
     target_model: Optional[str] = Field(None, description="Target Model (Fuzzy Match)")
@@ -180,6 +186,12 @@ class LogCostStatsQuery(BaseModel):
     # Time Range
     start_time: Optional[datetime] = Field(None, description="Start Time")
     end_time: Optional[datetime] = Field(None, description="End Time")
+    # Relative time range preset (e.g. "24h"). Ignored when start_time is provided.
+    timeline: Optional[str] = Field(
+        None,
+        pattern="^(1h|3h|6h|12h|24h|1w)$",
+        description="Relative time range preset. Ignored when start_time is provided.",
+    )
     # Core dimensions
     requested_model: Optional[str] = Field(None, description="Requested Model (Exact or fuzzy)")
     provider_id: Optional[int] = Field(None, description="Provider ID")

--- a/backend/app/domain/log.py
+++ b/backend/app/domain/log.py
@@ -286,3 +286,10 @@ class ModelProviderStats(BaseModel):
     avg_response_time_ms: Optional[float] = None
     success_rate: float = 0.0
     failure_rate: float = 0.0
+
+
+class ApiKeyMonthlyCost(BaseModel):
+    """API Key monthly cost summary"""
+
+    api_key_id: int
+    total_cost: float = 0.0

--- a/backend/app/repositories/log_repo.py
+++ b/backend/app/repositories/log_repo.py
@@ -15,6 +15,7 @@ from app.domain.log import (
     LogCostStatsResponse,
     ModelStats,
     ModelProviderStats,
+    ApiKeyMonthlyCost,
 )
 
 
@@ -88,4 +89,20 @@ class LogRepository(ABC):
         self, requested_model: str | None = None
     ) -> list[ModelProviderStats]:
         """Get aggregated model-provider stats for logs"""
+        pass
+
+    @abstractmethod
+    async def get_api_key_monthly_costs(
+        self, api_key_ids: list[int] | None = None
+    ) -> list[ApiKeyMonthlyCost]:
+        """
+        Get current month's total cost grouped by API Key ID
+
+        Args:
+            api_key_ids: Optional list of API Key IDs to filter.
+                         If None, returns stats for all API Keys with costs.
+
+        Returns:
+            list[ApiKeyMonthlyCost]: List of API Key monthly cost summaries
+        """
         pass

--- a/backend/app/repositories/sqlalchemy/model_repo.py
+++ b/backend/app/repositories/sqlalchemy/model_repo.py
@@ -55,6 +55,10 @@ class SQLAlchemyModelRepository(ModelRepository):
             is_active=entity.is_active,
             input_price=float(entity.input_price) if entity.input_price is not None else None,
             output_price=float(entity.output_price) if entity.output_price is not None else None,
+            billing_mode=entity.billing_mode,
+            per_request_price=float(entity.per_request_price) if entity.per_request_price is not None else None,
+            per_image_price=float(entity.per_image_price) if entity.per_image_price is not None else None,
+            tiered_pricing=entity.tiered_pricing,
             created_at=ensure_utc(entity.created_at),
             updated_at=ensure_utc(entity.updated_at),
         )
@@ -81,6 +85,9 @@ class SQLAlchemyModelRepository(ModelRepository):
             billing_mode=entity.billing_mode,
             per_request_price=float(entity.per_request_price)
             if entity.per_request_price is not None
+            else None,
+            per_image_price=float(entity.per_image_price)
+            if entity.per_image_price is not None
             else None,
             tiered_pricing=entity.tiered_pricing,
             priority=entity.priority,
@@ -231,6 +238,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             output_price=data.output_price,
             billing_mode=data.billing_mode,
             per_request_price=data.per_request_price,
+            per_image_price=data.per_image_price,
             tiered_pricing=[
                 t.model_dump() for t in (data.tiered_pricing or [])
             ]

--- a/backend/app/rules/engine.py
+++ b/backend/app/rules/engine.py
@@ -86,13 +86,18 @@ class RuleEngine:
                         input_price=pm.input_price,
                         output_price=pm.output_price,
                         per_request_price=pm.per_request_price,
+                        per_image_price=pm.per_image_price,
                         tiered_pricing=pm.tiered_pricing,
                         model_input_price=model_mapping.input_price,
                         model_output_price=model_mapping.output_price,
+                        model_billing_mode=model_mapping.billing_mode,
+                        model_per_request_price=model_mapping.per_request_price,
+                        model_per_image_price=model_mapping.per_image_price,
+                        model_tiered_pricing=model_mapping.tiered_pricing,
                         provider_mapping_id=pm.id,
                     )
                 )
-        
+
         # 3. Sort by priority (lower value means higher priority)
         candidates.sort(
             key=lambda c: (
@@ -102,9 +107,9 @@ class RuleEngine:
                 c.provider_mapping_id or 0,
             )
         )
-        
+
         return candidates
-    
+
     def evaluate_sync(
         self,
         context: RuleContext,
@@ -123,11 +128,11 @@ class RuleEngine:
         for pm in provider_mappings:
             if not pm.is_active:
                 continue
-            
+
             provider = providers.get(pm.provider_id)
             if not provider or not provider.is_active:
                 continue
-            
+
             provider_rules = RuleSet.from_dict(pm.provider_rules)
             if self.evaluator.evaluate_ruleset(provider_rules, context):
                 candidates.append(
@@ -148,13 +153,18 @@ class RuleEngine:
                         input_price=pm.input_price,
                         output_price=pm.output_price,
                         per_request_price=pm.per_request_price,
+                        per_image_price=pm.per_image_price,
                         tiered_pricing=pm.tiered_pricing,
                         model_input_price=model_mapping.input_price,
                         model_output_price=model_mapping.output_price,
+                        model_billing_mode=model_mapping.billing_mode,
+                        model_per_request_price=model_mapping.per_request_price,
+                        model_per_image_price=model_mapping.per_image_price,
+                        model_tiered_pricing=model_mapping.tiered_pricing,
                         provider_mapping_id=pm.id,
                     )
                 )
-        
+
         # Sort by priority (lower value means higher priority)
         candidates.sort(
             key=lambda c: (

--- a/backend/app/rules/models.py
+++ b/backend/app/rules/models.py
@@ -97,10 +97,11 @@ class CandidateProvider:
         target_model: Target Model Name (Actual model corresponding to this provider)
         priority: Priority (Lower value means higher priority)
         weight: Weight (Used for weighted selection)
-        billing_mode: Billing mode (token_flat/token_tiered/per_request)
+        billing_mode: Billing mode (token_flat/token_tiered/per_request/per_image)
         input_price: Provider input token price override (USD per 1M tokens)
         output_price: Provider output token price override (USD per 1M tokens)
         per_request_price: Per-request price (USD)
+        per_image_price: Per-image price (USD)
         tiered_pricing: Tiered pricing configuration
         model_input_price: Model fallback input price (USD per 1M tokens)
         model_output_price: Model fallback output price (USD per 1M tokens)
@@ -122,7 +123,12 @@ class CandidateProvider:
     input_price: Optional[float] = None
     output_price: Optional[float] = None
     per_request_price: Optional[float] = None
+    per_image_price: Optional[float] = None
     tiered_pricing: Optional[list[Any]] = None
     model_input_price: Optional[float] = None
     model_output_price: Optional[float] = None
+    model_billing_mode: Optional[str] = None
+    model_per_request_price: Optional[float] = None
+    model_per_image_price: Optional[float] = None
+    model_tiered_pricing: Optional[list[Any]] = None
     provider_mapping_id: Optional[int] = None

--- a/backend/app/services/log_service.py
+++ b/backend/app/services/log_service.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from app.common.errors import NotFoundError
 from app.domain.log import (
+    ApiKeyMonthlyCost,
     RequestLogModel,
     RequestLogCreate,
     RequestLogResponse,
@@ -144,3 +145,18 @@ class LogService:
         self, requested_model: str | None = None
     ) -> list[ModelProviderStats]:
         return await self.repo.get_model_provider_stats(requested_model)
+
+    async def get_api_key_monthly_costs(
+        self, api_key_ids: list[int] | None = None
+    ) -> list[ApiKeyMonthlyCost]:
+        """
+        Get current month's total cost grouped by API Key ID
+
+        Args:
+            api_key_ids: Optional list of API Key IDs to filter.
+                         If None, returns stats for all API Keys with costs.
+
+        Returns:
+            list[ApiKeyMonthlyCost]: List of API Key monthly cost summaries
+        """
+        return await self.repo.get_api_key_monthly_costs(api_key_ids)

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -187,8 +187,13 @@ class ModelService:
                     input_tokens=data.input_tokens,
                     model_input_price=candidate.model_input_price,
                     model_output_price=candidate.model_output_price,
+                    model_billing_mode=candidate.model_billing_mode,
+                    model_per_request_price=candidate.model_per_request_price,
+                    model_per_image_price=candidate.model_per_image_price,
+                    model_tiered_pricing=candidate.model_tiered_pricing,
                     provider_billing_mode=candidate.billing_mode,
                     provider_per_request_price=candidate.per_request_price,
+                    provider_per_image_price=candidate.per_image_price,
                     provider_tiered_pricing=candidate.tiered_pricing,
                     provider_input_price=candidate.input_price,
                     provider_output_price=candidate.output_price,
@@ -200,7 +205,7 @@ class ModelService:
                 )
                 estimated_cost = (
                     cost_breakdown.total_cost
-                    if billing.billing_mode == "per_request"
+                    if billing.billing_mode in ("per_request", "per_image")
                     else cost_breakdown.input_cost
                 )
             except Exception:
@@ -218,6 +223,7 @@ class ModelService:
                     input_price=candidate.input_price,
                     output_price=candidate.output_price,
                     per_request_price=candidate.per_request_price,
+                    per_image_price=candidate.per_image_price,
                     tiered_pricing=candidate.tiered_pricing,
                     model_input_price=candidate.model_input_price,
                     model_output_price=candidate.model_output_price,
@@ -469,11 +475,12 @@ class ModelService:
             "output_price": existing.output_price,
             "billing_mode": existing.billing_mode or "token_flat",
             "per_request_price": existing.per_request_price,
+            "per_image_price": existing.per_image_price,
             "tiered_pricing": existing.tiered_pricing,
         }
         merged.update(update_data)
         ModelMappingProviderCreate(**merged)
-        
+
         result = await self.model_repo.update_provider_mapping(id, data)
         return result  # type: ignore
 
@@ -524,6 +531,7 @@ class ModelService:
             input_price=data.input_price,
             output_price=data.output_price,
             per_request_price=data.per_request_price,
+            per_image_price=data.per_image_price,
             tiered_pricing=data.tiered_pricing,
         )
 
@@ -543,6 +551,7 @@ class ModelService:
                 "output_price": existing.output_price,
                 "billing_mode": existing.billing_mode or "token_flat",
                 "per_request_price": existing.per_request_price,
+                "per_image_price": existing.per_image_price,
                 "tiered_pricing": existing.tiered_pricing,
             }
             merged.update(update_data.model_dump(exclude_unset=True))
@@ -613,6 +622,7 @@ class ModelService:
                         output_price=pm.output_price,
                         billing_mode=pm.billing_mode,
                         per_request_price=pm.per_request_price,
+                        per_image_price=pm.per_image_price,
                         tiered_pricing=pm.tiered_pricing,
                         priority=pm.priority,
                         weight=pm.weight,
@@ -629,6 +639,10 @@ class ModelService:
                     is_active=m.is_active,
                     input_price=m.input_price,
                     output_price=m.output_price,
+                    billing_mode=m.billing_mode,
+                    per_request_price=m.per_request_price,
+                    per_image_price=m.per_image_price,
+                    tiered_pricing=m.tiered_pricing,
                     providers=providers_export
                 )
             )
@@ -690,6 +704,7 @@ class ModelService:
                             output_price=output_price,
                             billing_mode=billing_mode,
                             per_request_price=p_item.per_request_price,
+                            per_image_price=p_item.per_image_price,
                             tiered_pricing=p_item.tiered_pricing,
                             priority=p_item.priority,
                             weight=p_item.weight,
@@ -739,6 +754,10 @@ class ModelService:
             is_active=mapping.is_active,
             input_price=mapping.input_price,
             output_price=mapping.output_price,
+            billing_mode=mapping.billing_mode,
+            per_request_price=mapping.per_request_price,
+            per_image_price=mapping.per_image_price,
+            tiered_pricing=mapping.tiered_pricing,
             created_at=mapping.created_at,
             updated_at=mapping.updated_at,
             provider_count=provider_count,

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -397,6 +397,14 @@ class ProxyService:
         )
         token_counter = get_token_counter(protocol)
 
+        # Extract image count for per-image billing
+        image_count: Optional[int] = None
+        if path in OPENAI_IMAGE_PATHS:
+            try:
+                image_count = int(body.get("n") or 1)
+            except (ValueError, TypeError):
+                image_count = 1
+
         # DEBUG: Log matched providers
         candidates_info = [
             {
@@ -433,10 +441,17 @@ class ProxyService:
                 input_tokens=input_tokens,
                 model_input_price=model_mapping.input_price,
                 model_output_price=model_mapping.output_price,
+                model_billing_mode=model_mapping.billing_mode,
+                model_per_request_price=model_mapping.per_request_price,
+                model_per_image_price=model_mapping.per_image_price,
+                model_tiered_pricing=model_mapping.tiered_pricing,
                 provider_billing_mode=provider_mapping.billing_mode
                 if provider_mapping
                 else None,
                 provider_per_request_price=provider_mapping.per_request_price
+                if provider_mapping
+                else None,
+                provider_per_image_price=provider_mapping.per_image_price
                 if provider_mapping
                 else None,
                 provider_tiered_pricing=provider_mapping.tiered_pricing
@@ -600,6 +615,7 @@ class ProxyService:
             requested_model=requested_model,
             forward_fn=forward_fn,
             input_tokens=input_tokens,
+            image_count=image_count,
             on_failure_attempt=log_failed_attempt,
         )
 
@@ -739,6 +755,9 @@ class ProxyService:
             provider_per_request_price=provider_mapping.per_request_price
             if provider_mapping
             else None,
+            provider_per_image_price=provider_mapping.per_image_price
+            if provider_mapping
+            else None,
             provider_tiered_pricing=provider_mapping.tiered_pricing
             if provider_mapping
             else None,
@@ -753,6 +772,7 @@ class ProxyService:
             billing=billing,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            image_count=image_count,
         )
         log_data = RequestLogCreate(
             request_time=request_time,
@@ -868,6 +888,14 @@ class ProxyService:
             headers=headers,
             body=body,
         )
+
+        # Extract image count for per-image billing
+        image_count: Optional[int] = None
+        if path in OPENAI_IMAGE_PATHS:
+            try:
+                image_count = int(body.get("n") or 1)
+            except (ValueError, TypeError):
+                image_count = 1
 
         # DEBUG: Log matched providers
         candidates_info = [
@@ -1126,10 +1154,17 @@ class ProxyService:
                 input_tokens=input_tokens,
                 model_input_price=model_mapping.input_price,
                 model_output_price=model_mapping.output_price,
+                model_billing_mode=model_mapping.billing_mode,
+                model_per_request_price=model_mapping.per_request_price,
+                model_per_image_price=model_mapping.per_image_price,
+                model_tiered_pricing=model_mapping.tiered_pricing,
                 provider_billing_mode=provider_mapping.billing_mode
                 if provider_mapping
                 else None,
                 provider_per_request_price=provider_mapping.per_request_price
+                if provider_mapping
+                else None,
+                provider_per_image_price=provider_mapping.per_image_price
                 if provider_mapping
                 else None,
                 provider_tiered_pricing=provider_mapping.tiered_pricing
@@ -1194,6 +1229,7 @@ class ProxyService:
             requested_model,
             forward_stream_fn,
             input_tokens=input_tokens,
+            image_count=image_count,
             on_failure_attempt=log_failed_attempt,
         )
 
@@ -1288,6 +1324,9 @@ class ProxyService:
                     provider_per_request_price=provider_mapping.per_request_price
                     if provider_mapping
                     else None,
+                    provider_per_image_price=provider_mapping.per_image_price
+                    if provider_mapping
+                    else None,
                     provider_tiered_pricing=provider_mapping.tiered_pricing
                     if provider_mapping
                     else None,
@@ -1302,6 +1341,7 @@ class ProxyService:
                     billing=billing,
                     input_tokens=input_tokens,
                     output_tokens=usage_result.output_tokens,
+                    image_count=image_count,
                 )
                 raw_stream_text = (
                     b"".join(raw_stream_chunks).decode("utf-8", errors="replace")

--- a/backend/tests/unit/test_common/test_model_billing_validation.py
+++ b/backend/tests/unit/test_common/test_model_billing_validation.py
@@ -1,0 +1,199 @@
+"""Unit tests for billing mode validation in model domain DTOs."""
+
+import pytest
+from app.domain.model import (
+    ModelMappingCreate,
+    ModelMappingProviderCreate,
+    ModelProviderBulkUpgradeRequest,
+    TokenTierPrice,
+)
+
+
+# ============ ModelMappingProviderCreate ============
+
+
+def test_per_image_billing_mode_requires_per_image_price():
+    with pytest.raises(ValueError, match="per_image_price is required"):
+        ModelMappingProviderCreate(
+            requested_model="dall-e-3",
+            provider_id=1,
+            target_model_name="dall-e-3",
+            billing_mode="per_image",
+        )
+
+
+def test_per_image_billing_mode_valid():
+    obj = ModelMappingProviderCreate(
+        requested_model="dall-e-3",
+        provider_id=1,
+        target_model_name="dall-e-3",
+        billing_mode="per_image",
+        per_image_price=0.04,
+    )
+    assert obj.billing_mode == "per_image"
+    assert obj.per_image_price == 0.04
+
+
+def test_per_image_billing_mode_zero_price_valid():
+    obj = ModelMappingProviderCreate(
+        requested_model="dall-e-3",
+        provider_id=1,
+        target_model_name="dall-e-3",
+        billing_mode="per_image",
+        per_image_price=0.0,
+    )
+    assert obj.per_image_price == 0.0
+
+
+def test_per_image_billing_mode_negative_price_rejected():
+    with pytest.raises(Exception):
+        ModelMappingProviderCreate(
+            requested_model="dall-e-3",
+            provider_id=1,
+            target_model_name="dall-e-3",
+            billing_mode="per_image",
+            per_image_price=-1.0,
+        )
+
+
+def test_token_flat_billing_still_works():
+    obj = ModelMappingProviderCreate(
+        requested_model="gpt-4",
+        provider_id=1,
+        target_model_name="gpt-4",
+        billing_mode="token_flat",
+        input_price=5.0,
+        output_price=15.0,
+    )
+    assert obj.billing_mode == "token_flat"
+
+
+def test_per_request_billing_still_works():
+    obj = ModelMappingProviderCreate(
+        requested_model="dall-e-3",
+        provider_id=1,
+        target_model_name="dall-e-3",
+        billing_mode="per_request",
+        per_request_price=0.04,
+    )
+    assert obj.billing_mode == "per_request"
+
+
+# ============ ModelProviderBulkUpgradeRequest ============
+
+
+def test_bulk_upgrade_per_image_requires_per_image_price():
+    with pytest.raises(ValueError, match="per_image_price is required"):
+        ModelProviderBulkUpgradeRequest(
+            provider_id=1,
+            current_target_model_name="old-model",
+            new_target_model_name="new-model",
+            billing_mode="per_image",
+        )
+
+
+def test_bulk_upgrade_per_image_valid():
+    obj = ModelProviderBulkUpgradeRequest(
+        provider_id=1,
+        current_target_model_name="old-model",
+        new_target_model_name="new-model",
+        billing_mode="per_image",
+        per_image_price=0.02,
+    )
+    assert obj.billing_mode == "per_image"
+    assert obj.per_image_price == 0.02
+
+
+# ============ ModelMappingCreate (model-level billing) ============
+
+
+def test_model_create_no_billing_mode_allows_empty():
+    """billing_mode=None is the legacy default, should not require any billing fields."""
+    obj = ModelMappingCreate(requested_model="test-model")
+    assert obj.billing_mode is None
+    assert obj.input_price is None
+    assert obj.per_request_price is None
+
+
+def test_model_create_per_request_requires_price():
+    with pytest.raises(ValueError, match="per_request_price is required"):
+        ModelMappingCreate(
+            requested_model="test-model",
+            billing_mode="per_request",
+        )
+
+
+def test_model_create_per_request_valid():
+    obj = ModelMappingCreate(
+        requested_model="test-model",
+        billing_mode="per_request",
+        per_request_price=0.05,
+    )
+    assert obj.billing_mode == "per_request"
+    assert obj.per_request_price == 0.05
+
+
+def test_model_create_per_image_requires_price():
+    with pytest.raises(ValueError, match="per_image_price is required"):
+        ModelMappingCreate(
+            requested_model="dall-e-3",
+            billing_mode="per_image",
+        )
+
+
+def test_model_create_per_image_valid():
+    obj = ModelMappingCreate(
+        requested_model="dall-e-3",
+        billing_mode="per_image",
+        per_image_price=0.04,
+    )
+    assert obj.billing_mode == "per_image"
+    assert obj.per_image_price == 0.04
+
+
+def test_model_create_token_tiered_requires_tiers():
+    with pytest.raises(ValueError, match="tiered_pricing is required"):
+        ModelMappingCreate(
+            requested_model="test-model",
+            billing_mode="token_tiered",
+        )
+
+
+def test_model_create_token_tiered_valid():
+    obj = ModelMappingCreate(
+        requested_model="test-model",
+        billing_mode="token_tiered",
+        tiered_pricing=[
+            TokenTierPrice(max_input_tokens=32768, input_price=1.0, output_price=2.0),
+        ],
+    )
+    assert obj.billing_mode == "token_tiered"
+    assert len(obj.tiered_pricing) == 1
+
+
+def test_model_create_token_flat_requires_both_prices():
+    with pytest.raises(ValueError, match="input_price and output_price"):
+        ModelMappingCreate(
+            requested_model="test-model",
+            billing_mode="token_flat",
+        )
+
+
+def test_model_create_token_flat_valid():
+    obj = ModelMappingCreate(
+        requested_model="test-model",
+        billing_mode="token_flat",
+        input_price=5.0,
+        output_price=15.0,
+    )
+    assert obj.billing_mode == "token_flat"
+    assert obj.input_price == 5.0
+
+
+def test_model_create_per_image_negative_rejected():
+    with pytest.raises(Exception):
+        ModelMappingCreate(
+            requested_model="dall-e-3",
+            billing_mode="per_image",
+            per_image_price=-1.0,
+        )

--- a/backend/tests/unit/test_common/test_model_level_billing.py
+++ b/backend/tests/unit/test_common/test_model_level_billing.py
@@ -1,0 +1,218 @@
+"""
+Tests for model-level billing mode fallback in resolve_billing.
+
+When a provider has no billing_mode set, the model's billing_mode
+should be used as fallback. Provider billing always takes priority.
+"""
+
+import pytest
+from app.common.costs import (
+    BILLING_MODE_PER_IMAGE,
+    BILLING_MODE_PER_REQUEST,
+    BILLING_MODE_TOKEN_FLAT,
+    BILLING_MODE_TOKEN_TIERED,
+    PRICE_SOURCE_DEFAULT_ZERO,
+    PRICE_SOURCE_MODEL_FALLBACK,
+    PRICE_SOURCE_SUPPLIER_OVERRIDE,
+    calculate_cost_from_billing,
+    resolve_billing,
+)
+
+
+class TestModelLevelBillingFallback:
+    """Test that model-level billing_mode works as fallback when provider has none."""
+
+    def test_model_per_request_as_fallback(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=2.0,
+            model_output_price=3.0,
+            model_billing_mode="per_request",
+            model_per_request_price=0.05,
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_REQUEST
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.per_request_price == 0.05
+
+    def test_model_per_image_as_fallback(self):
+        billing = resolve_billing(
+            input_tokens=0,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="per_image",
+            model_per_image_price=0.04,
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_per_image_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_IMAGE
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.per_image_price == 0.04
+        # Verify cost calculation with image_count
+        cost = calculate_cost_from_billing(
+            input_tokens=0,
+            output_tokens=0,
+            billing=billing,
+            image_count=3,
+        )
+        assert cost.total_cost == pytest.approx(0.12)
+
+    def test_model_token_tiered_as_fallback(self):
+        tiers = [
+            {"max_input_tokens": 32768, "input_price": 1.0, "output_price": 2.0},
+            {"max_input_tokens": None, "input_price": 3.0, "output_price": 4.0},
+        ]
+        billing = resolve_billing(
+            input_tokens=50000,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="token_tiered",
+            model_tiered_pricing=tiers,
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_TIERED
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        # 50000 > 32768 → falls into 2nd tier
+        assert billing.input_price == 3.0
+        assert billing.output_price == 4.0
+
+    def test_model_token_flat_as_fallback(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode="token_flat",
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        # token_flat with model_billing_mode still goes through resolve_price
+        assert billing.input_price == 5.0
+        assert billing.output_price == 15.0
+
+
+class TestProviderOverridesModelBilling:
+    """Test that provider billing always takes priority over model billing."""
+
+    def test_provider_overrides_model_per_request(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=2.0,
+            model_output_price=3.0,
+            model_billing_mode="per_request",
+            model_per_request_price=0.10,
+            provider_billing_mode="token_flat",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=10.0,
+            provider_output_price=20.0,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_SUPPLIER_OVERRIDE
+        assert billing.input_price == 10.0
+        assert billing.output_price == 20.0
+
+    def test_provider_per_image_overrides_model_per_request(self):
+        billing = resolve_billing(
+            input_tokens=0,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="per_request",
+            model_per_request_price=0.10,
+            provider_billing_mode="per_image",
+            provider_per_request_price=None,
+            provider_per_image_price=0.02,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_IMAGE
+        assert billing.price_source == PRICE_SOURCE_SUPPLIER_OVERRIDE
+        assert billing.per_image_price == 0.02
+
+
+class TestNoModelNoProviderBilling:
+    """Test fallback when neither model nor provider set billing_mode."""
+
+    def test_defaults_to_token_flat_with_zero(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=None,
+            model_output_price=None,
+            model_billing_mode=None,
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_DEFAULT_ZERO
+        assert billing.input_price == 0.0
+        assert billing.output_price == 0.0
+
+    def test_model_fallback_prices_used_without_billing_mode(self):
+        """When model has input/output prices but no billing_mode, they serve as token_flat fallback."""
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode=None,
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.input_price == 5.0
+        assert billing.output_price == 15.0
+
+
+class TestBackwardCompatibility:
+    """Test that existing calls without model_billing_mode params work unchanged."""
+
+    def test_call_without_model_billing_params(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=2.0,
+            model_output_price=3.0,
+            provider_billing_mode="per_request",
+            provider_per_request_price=0.01,
+            provider_tiered_pricing=None,
+            provider_input_price=9.9,
+            provider_output_price=9.9,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_REQUEST
+        assert billing.per_request_price == 0.01
+
+    def test_call_without_model_billing_params_per_image(self):
+        billing = resolve_billing(
+            input_tokens=0,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            provider_billing_mode="per_image",
+            provider_per_request_price=None,
+            provider_per_image_price=0.05,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_IMAGE
+        assert billing.per_image_price == 0.05

--- a/backend/tests/unit/test_services/test_model_service_provider_mapping.py
+++ b/backend/tests/unit/test_services/test_model_service_provider_mapping.py
@@ -6,6 +6,7 @@ import pytest
 from app.domain.model import (
     ModelMappingCreate,
     ModelMappingProviderCreate,
+    ModelMappingProviderUpdate,
     ModelProviderBulkUpgradeRequest,
 )
 from app.domain.provider import ProviderCreate
@@ -144,3 +145,125 @@ async def test_bulk_upgrade_provider_model_updates_all_matched_mappings(db_sessi
         assert mapping.target_model_name == "new-model"
         assert mapping.billing_mode == "per_request"
         assert mapping.per_request_price == 0.003
+
+
+@pytest.mark.asyncio
+async def test_create_provider_mapping_per_image_billing(db_session):
+    """Create a provider mapping with per_image billing mode."""
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    service = ModelService(model_repo, provider_repo)
+
+    await model_repo.create_mapping(
+        ModelMappingCreate(requested_model="dall-e-3", model_type="images")
+    )
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="openai-img",
+            base_url="https://api.openai.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+
+    created = await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="dall-e-3",
+            provider_id=provider.id,
+            target_model_name="dall-e-3",
+            billing_mode="per_image",
+            per_image_price=0.04,
+        )
+    )
+    assert created.billing_mode == "per_image"
+    assert created.per_image_price == 0.04
+    assert created.provider_name == "openai-img"
+
+
+@pytest.mark.asyncio
+async def test_update_provider_mapping_to_per_image_billing(db_session):
+    """Update a provider mapping from token_flat to per_image billing."""
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    service = ModelService(model_repo, provider_repo)
+
+    await model_repo.create_mapping(
+        ModelMappingCreate(requested_model="dall-e-3", model_type="images")
+    )
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="openai-img2",
+            base_url="https://api.openai.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+
+    created = await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="dall-e-3",
+            provider_id=provider.id,
+            target_model_name="dall-e-3",
+            billing_mode="token_flat",
+            input_price=5.0,
+            output_price=15.0,
+        )
+    )
+
+    updated = await service.update_provider_mapping(
+        created.id,
+        ModelMappingProviderUpdate(
+            billing_mode="per_image",
+            per_image_price=0.08,
+        ),
+    )
+    assert updated.billing_mode == "per_image"
+    assert updated.per_image_price == 0.08
+
+
+@pytest.mark.asyncio
+async def test_bulk_upgrade_per_image_billing(db_session):
+    """Bulk upgrade provider mappings to per_image billing."""
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    service = ModelService(model_repo, provider_repo)
+
+    await model_repo.create_mapping(
+        ModelMappingCreate(requested_model="img-model", model_type="images")
+    )
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="p-img-bulk",
+            base_url="https://example.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+
+    await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="img-model",
+            provider_id=provider.id,
+            target_model_name="old-img",
+            billing_mode="token_flat",
+            input_price=1.0,
+            output_price=2.0,
+        )
+    )
+
+    updated_count = await service.bulk_upgrade_provider_model(
+        ModelProviderBulkUpgradeRequest(
+            provider_id=provider.id,
+            current_target_model_name="old-img",
+            new_target_model_name="new-img",
+            billing_mode="per_image",
+            per_image_price=0.06,
+        )
+    )
+    assert updated_count == 1
+
+    mappings = await service.get_provider_mappings(provider_id=provider.id)
+    assert len(mappings) == 1
+    assert mappings[0].target_model_name == "new-img"
+    assert mappings[0].billing_mode == "per_image"
+    assert mappings[0].per_image_price == 0.06

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -448,9 +448,11 @@
       "billingDisplay": {
         "free": "free",
         "perRequestEmpty": "Per request: -",
+        "perImageEmpty": "Per image: -",
         "tieredEmpty": "Tiered: -",
         "tokenFlat": "Token: {input}/{output} (per 1M)",
         "perRequest": "Per request: {price}",
+        "perImage": "Per image: {price}",
         "tieredPreview": "Tiered: {preview}{more}",
         "tieredPreviewMore": " (+{count})",
         "tieredEntry": "≤{max}: {input}/{output}"
@@ -485,9 +487,11 @@
       "billingMode": "Billing Mode",
       "billingModePlaceholder": "Select billing mode",
       "billingModePerRequest": "Per request",
+      "billingModePerImage": "Per image",
       "billingModeTokenFlat": "Per token (flat)",
       "billingModeTokenTiered": "Per token (tiered by input tokens)",
       "pricePerRequest": "Price (USD / request)",
+      "pricePerImage": "Price (USD / image)",
       "tieredHint": "Choose the tier by input tokens, then bill input/output tokens separately by that tier’s prices.",
       "maxInputTokens": "Max Input Tokens",
       "tierInputPrice": "Input (USD / 1M)",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -124,6 +124,7 @@
         "id": "ID",
         "name": "Name",
         "key": "API Key",
+        "monthlyCost": "Monthly Cost",
         "status": "Status",
         "createdAt": "Created At",
         "lastUsed": "Last Used",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -448,9 +448,11 @@
       "billingDisplay": {
         "free": "免费",
         "perRequestEmpty": "按请求计费：-",
+        "perImageEmpty": "按图片计费：-",
         "tieredEmpty": "分档：-",
         "tokenFlat": "Token：{input}/{output}（每 1M）",
         "perRequest": "按请求计费：{price}",
+        "perImage": "按图片计费：{price}",
         "tieredPreview": "分档：{preview}{more}",
         "tieredPreviewMore": " (+{count})",
         "tieredEntry": "≤{max}: {input}/{output}"
@@ -485,9 +487,11 @@
       "billingMode": "计费方式",
       "billingModePlaceholder": "选择计费方式",
       "billingModePerRequest": "按请求计费",
+      "billingModePerImage": "按图片计费",
       "billingModeTokenFlat": "按 token 计费（固定）",
       "billingModeTokenTiered": "按 token 计费（按输入 token 分档）",
       "pricePerRequest": "价格（美元/请求）",
+      "pricePerImage": "价格（美元/张）",
       "tieredHint": "先按输入 token 选档，再按档位价格分别计费输入/输出 token。",
       "maxInputTokens": "最大输入 tokens",
       "tierInputPrice": "输入（美元/1M）",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -124,6 +124,7 @@
         "id": "ID",
         "name": "名称",
         "key": "API Key",
+        "monthlyCost": "本月消费",
         "status": "状态",
         "createdAt": "创建时间",
         "lastUsed": "最近使用",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -300,6 +301,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2392,6 +2835,356 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "dev": true,
@@ -2399,6 +3192,13 @@
     },
     "node_modules/@schummar/icu-type-parser": {
       "version": "1.21.5",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {
@@ -2873,6 +3673,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -2883,6 +3694,13 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "http://mirrors.tencentyun.com/npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2904,6 +3722,7 @@
       "version": "20.19.30",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3447,6 +4266,117 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "dev": true,
@@ -3663,6 +4593,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "dev": true,
@@ -3852,6 +4792,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "http://mirrors.tencentyun.com/npm/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4222,6 +5172,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -4270,6 +5227,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -4667,6 +5666,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -4678,6 +5687,16 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4826,6 +5845,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6334,6 +7368,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -6423,6 +7468,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6806,6 +7858,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -7073,6 +8170,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "license": "MIT",
@@ -7090,6 +8194,20 @@
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "http://mirrors.tencentyun.com/npm/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7299,6 +8417,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "http://mirrors.tencentyun.com/npm/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "dev": true,
@@ -7340,6 +8475,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7859,6 +9004,204 @@
         "node": ">=12"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "http://mirrors.tencentyun.com/npm/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "http://mirrors.tencentyun.com/npm/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -7952,6 +9295,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -80,7 +80,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -225,7 +224,6 @@
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -274,8 +272,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -294,8 +290,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -305,7 +299,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
       "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
@@ -322,7 +316,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
       "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
@@ -339,7 +333,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
       "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
@@ -356,7 +350,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
       "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
@@ -373,7 +367,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
       "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
@@ -390,7 +384,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
       "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
@@ -407,7 +401,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
       "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
@@ -424,7 +418,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
       "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
@@ -441,7 +435,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
       "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
@@ -458,7 +452,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
       "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
@@ -475,7 +469,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
       "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
@@ -492,7 +486,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
       "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
@@ -509,7 +503,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
       "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
@@ -526,7 +520,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
       "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
@@ -543,7 +537,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
       "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
@@ -560,7 +554,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
       "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
@@ -577,7 +571,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
       "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
@@ -594,7 +588,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
       "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
@@ -611,7 +605,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
       "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
@@ -628,7 +622,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
       "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
@@ -645,7 +639,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
       "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
@@ -662,7 +656,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
       "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
       "cpu": [
         "arm64"
@@ -679,7 +673,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
       "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
@@ -696,7 +690,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
       "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
@@ -713,7 +707,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
       "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
@@ -730,7 +724,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
       "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
@@ -1494,8 +1488,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2837,7 +2829,7 @@
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
       "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
       "cpu": [
         "arm"
@@ -2851,7 +2843,7 @@
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
       "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
       "cpu": [
         "arm64"
@@ -2865,7 +2857,7 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
       "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
       "cpu": [
         "arm64"
@@ -2879,7 +2871,7 @@
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
       "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
       "cpu": [
         "x64"
@@ -2893,7 +2885,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
       "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
       "cpu": [
         "arm64"
@@ -2907,7 +2899,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
       "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
       "cpu": [
         "x64"
@@ -2921,7 +2913,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
       "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
       "cpu": [
         "arm"
@@ -2935,7 +2927,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
       "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
       "cpu": [
         "arm"
@@ -2949,7 +2941,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
       "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
       "cpu": [
         "arm64"
@@ -2963,7 +2955,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
       "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
       "cpu": [
         "arm64"
@@ -2977,7 +2969,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
       "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
       "cpu": [
         "loong64"
@@ -2991,7 +2983,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
       "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
       "cpu": [
         "loong64"
@@ -3005,7 +2997,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
       "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
       "cpu": [
         "ppc64"
@@ -3019,7 +3011,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
       "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
       "cpu": [
         "ppc64"
@@ -3033,7 +3025,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
       "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
       "cpu": [
         "riscv64"
@@ -3047,7 +3039,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
       "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
       "cpu": [
         "riscv64"
@@ -3061,7 +3053,7 @@
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
       "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
       "cpu": [
         "s390x"
@@ -3075,7 +3067,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
       "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
       "cpu": [
         "x64"
@@ -3089,7 +3081,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
       "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
       "cpu": [
         "x64"
@@ -3103,7 +3095,7 @@
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
       "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
       "cpu": [
         "x64"
@@ -3117,7 +3109,7 @@
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
       "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
       "cpu": [
         "arm64"
@@ -3131,7 +3123,7 @@
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
       "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
       "cpu": [
         "arm64"
@@ -3145,7 +3137,7 @@
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
       "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
       "cpu": [
         "ia32"
@@ -3159,7 +3151,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
       "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
       "cpu": [
         "x64"
@@ -3173,7 +3165,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
       "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
       "cpu": [
         "x64"
@@ -3196,7 +3188,7 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
@@ -3664,8 +3656,6 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3675,7 +3665,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/chai/-/chai-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
@@ -3684,11 +3674,32 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
@@ -3696,9 +3707,39 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
@@ -3722,7 +3763,6 @@
       "version": "20.19.30",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3731,7 +3771,6 @@
       "version": "19.2.10",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3740,7 +3779,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3784,7 +3822,6 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4268,7 +4305,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/expect/-/expect-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
       "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
       "dev": true,
       "license": "MIT",
@@ -4286,7 +4323,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
       "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
       "dev": true,
       "license": "MIT",
@@ -4313,7 +4350,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
       "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
@@ -4326,7 +4363,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/runner/-/runner-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
       "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
       "dev": true,
       "license": "MIT",
@@ -4340,7 +4377,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
       "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
       "dev": true,
       "license": "MIT",
@@ -4355,7 +4392,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/spy/-/spy-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
       "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
       "dev": true,
       "license": "MIT",
@@ -4365,7 +4402,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/@vitest/utils/-/utils-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
       "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dev": true,
       "license": "MIT",
@@ -4381,7 +4418,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4595,7 +4631,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/assertion-error/-/assertion-error-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
@@ -4709,7 +4745,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4795,7 +4830,7 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/chai/-/chai-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
@@ -4892,6 +4927,127 @@
       "version": "3.2.3",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "dev": true,
@@ -4965,6 +5121,12 @@
       "version": "10.6.0",
       "license": "MIT"
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -5029,6 +5191,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -5174,7 +5346,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
@@ -5231,7 +5403,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/esbuild/-/esbuild-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
@@ -5294,7 +5466,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5464,7 +5635,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5668,7 +5838,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/estree-walker/-/estree-walker-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
@@ -5686,11 +5856,13 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/expect-type/-/expect-type-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5702,6 +5874,15 @@
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5849,7 +6030,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -6176,6 +6357,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -6956,6 +7146,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -7370,7 +7562,7 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/obug/-/obug-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
@@ -7473,7 +7665,7 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/pathe/-/pathe-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
@@ -7583,7 +7775,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7591,7 +7782,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7675,41 +7865,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/react-smooth/node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/react-smooth/node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/react-smooth/node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "license": "MIT",
@@ -7728,6 +7883,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/recharts": {
@@ -7761,12 +7932,6 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
-    },
-    "node_modules/recharts-scale/node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
     },
     "node_modules/recharts/node_modules/react-is": {
       "version": "18.3.1",
@@ -7860,7 +8025,7 @@
     },
     "node_modules/rollup": {
       "version": "4.57.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/rollup/-/rollup-4.57.1.tgz",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
@@ -8172,7 +8337,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/siginfo/-/siginfo-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
@@ -8199,14 +8364,14 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/stackback/-/stackback-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/std-env/-/std-env-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
@@ -8419,14 +8584,14 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/tinybench/-/tinybench-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/tinyexec/-/tinyexec-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
       "dev": true,
       "license": "MIT",
@@ -8469,7 +8634,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8479,7 +8643,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
@@ -8620,7 +8784,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8823,190 +8986,9 @@
         "d3-timer": "^3.0.1"
       }
     },
-    "node_modules/victory-vendor/node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/victory-vendor/node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/victory-vendor/node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/victory-vendor/node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
-    "node_modules/victory-vendor/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/vite": {
       "version": "7.3.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/vite/-/vite-7.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
@@ -9081,7 +9063,7 @@
     },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -9099,11 +9081,10 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9113,7 +9094,7 @@
     },
     "node_modules/vitest": {
       "version": "4.0.18",
-      "resolved": "http://mirrors.tencentyun.com/npm/vitest/-/vitest-4.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
@@ -9191,7 +9172,7 @@
     },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
@@ -9299,7 +9280,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
@@ -9342,7 +9323,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -41,6 +42,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/app/models/detail/page.tsx
+++ b/frontend/src/app/models/detail/page.tsx
@@ -224,7 +224,7 @@ function ModelDetailContent() {
 
   const status = getActiveStatus(model.is_active);
   const modelType = model.model_type ?? 'chat';
-  const supportsBilling = modelType === 'chat' || modelType === 'embedding';
+  const supportsBilling = modelType === 'chat' || modelType === 'embedding' || modelType === 'images';
   const modelStats = modelStatsData?.find((stat) => stat.requested_model === requestedModel);
   const providerStats = providerStatsData ?? [];
 
@@ -275,11 +275,16 @@ function ModelDetailContent() {
             {supportsBilling && (
               <div className="md:col-span-2">
                 <p className="text-sm text-muted-foreground">{t('detail.pricing')}</p>
-                <p className="text-sm">
-                  <span className="font-mono">{formatPrice(model.input_price)}</span>
-                  <span className="mx-2 text-muted-foreground">/</span>
-                  <span className="font-mono">{formatPrice(model.output_price)}</span>
-                </p>
+                <div className="text-sm">
+                  <BillingDisplay
+                    billingMode={model.billing_mode}
+                    inputPrice={model.input_price}
+                    outputPrice={model.output_price}
+                    perRequestPrice={model.per_request_price}
+                    perImagePrice={model.per_image_price}
+                    tieredPricing={model.tiered_pricing}
+                  />
+                </div>
               </div>
             )}
           </div>
@@ -331,13 +336,15 @@ function ModelDetailContent() {
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>{t('detail.providerConfig')}</CardTitle>
           <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setTestDialogOpen(true)}
-            >
-              {t('actions.modelTest')}
-            </Button>
+            {modelType === 'chat' && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setTestDialogOpen(true)}
+              >
+                {t('actions.modelTest')}
+              </Button>
+            )}
             <Button
               variant="outline"
               size="sm"
@@ -416,6 +423,7 @@ function ModelDetailContent() {
                             inputPrice={mapping.input_price}
                             outputPrice={mapping.output_price}
                             perRequestPrice={mapping.per_request_price}
+                            perImagePrice={mapping.per_image_price}
                             tieredPricing={mapping.tiered_pricing}
                             fallbackInputPrice={model.input_price}
                             fallbackOutputPrice={model.output_price}
@@ -549,11 +557,13 @@ function ModelDetailContent() {
         loading={createMutation.isPending || updateMutation.isPending}
       />
 
-      <ModelTestDialog
-        open={testDialogOpen}
-        onOpenChange={setTestDialogOpen}
-        requestedModel={requestedModel}
-      />
+      {modelType === 'chat' && (
+        <ModelTestDialog
+          open={testDialogOpen}
+          onOpenChange={setTestDialogOpen}
+          requestedModel={requestedModel}
+        />
+      )}
 
       <ModelMatchDialog
         open={matchDialogOpen}

--- a/frontend/src/components/api-keys/ApiKeyList.tsx
+++ b/frontend/src/components/api-keys/ApiKeyList.tsx
@@ -20,7 +20,7 @@ import { Badge } from '@/components/ui/badge';
 import { Pencil, Trash2, Copy, Check, Eye, EyeOff, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ApiKey } from '@/types';
-import { formatDateTime, getActiveStatus } from '@/lib/utils';
+import { formatDateTime, getActiveStatus, formatUsdCompact } from '@/lib/utils';
 import { getRawKeyValue } from '@/lib/api/api-keys';
 
 interface ApiKeyListProps {
@@ -98,6 +98,7 @@ export function ApiKeyList({
           <TableHead className="w-[60px]">{t('list.columns.id')}</TableHead>
           <TableHead>{t('list.columns.name')}</TableHead>
           <TableHead>{t('list.columns.key')}</TableHead>
+          <TableHead>{t('list.columns.monthlyCost')}</TableHead>
           <TableHead>{t('list.columns.status')}</TableHead>
           <TableHead>{t('list.columns.createdAt')}</TableHead>
           <TableHead>{t('list.columns.lastUsed')}</TableHead>
@@ -156,6 +157,9 @@ export function ApiKeyList({
                     )}
                   </Button>
                 </div>
+              </TableCell>
+              <TableCell className="font-mono text-sm">
+                {formatUsdCompact(apiKey.monthly_cost)}
               </TableCell>
               <TableCell>
                 <Badge className={status.className}>

--- a/frontend/src/components/models/BillingDisplay.tsx
+++ b/frontend/src/components/models/BillingDisplay.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
-type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | null | undefined;
+type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null | undefined;
 
 interface BillingTier {
   max_input_tokens?: number | null;
@@ -22,6 +22,7 @@ interface BillingDisplayProps {
   inputPrice?: number | null;
   outputPrice?: number | null;
   perRequestPrice?: number | null;
+  perImagePrice?: number | null;
   tieredPricing?: BillingTier[] | null;
   fallbackInputPrice?: number | null;
   fallbackOutputPrice?: number | null;
@@ -58,6 +59,7 @@ export function BillingDisplay({
   inputPrice,
   outputPrice,
   perRequestPrice,
+  perImagePrice,
   tieredPricing,
   fallbackInputPrice,
   fallbackOutputPrice,
@@ -79,6 +81,16 @@ export function BillingDisplay({
     } else {
       text = t('detail.billingDisplay.perRequest', {
         price: formatUsdCeil4(perRequestPrice),
+      });
+    }
+  } else if (mode === 'per_image') {
+    if (perImagePrice === null || perImagePrice === undefined) {
+      text = t('detail.billingDisplay.perImageEmpty');
+    } else if (perImagePrice === 0) {
+      text = t('detail.billingDisplay.free');
+    } else {
+      text = t('detail.billingDisplay.perImage', {
+        price: formatUsdCeil4(perImagePrice),
       });
     }
   } else if (mode === 'token_tiered') {

--- a/frontend/src/components/models/ModelProviderBillingFields.tsx
+++ b/frontend/src/components/models/ModelProviderBillingFields.tsx
@@ -17,8 +17,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import type { ModelType } from '@/types';
 
-export type BillingMode = 'token_flat' | 'token_tiered' | 'per_request';
+export type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
 
 interface TierInputValue {
   max_input_tokens: string;
@@ -30,6 +31,7 @@ type BillingFormValues = FieldValues & {
   input_price: string;
   output_price: string;
   per_request_price: string;
+  per_image_price: string;
   tiers: TierInputValue[];
 };
 
@@ -44,6 +46,7 @@ interface ModelProviderBillingFieldsProps<TFormValues extends BillingFormValues>
   historyLoading?: boolean;
   onLoadHistory?: () => void;
   showHistoryButton?: boolean;
+  modelType?: ModelType;
 }
 
 export function ModelProviderBillingFields<TFormValues extends BillingFormValues>({
@@ -57,6 +60,7 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
   historyLoading = false,
   onLoadHistory,
   showHistoryButton = false,
+  modelType,
 }: ModelProviderBillingFieldsProps<TFormValues>) {
   return (
     <div className="rounded-lg border bg-muted/30 p-3 space-y-3">
@@ -88,15 +92,24 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
               <SelectValue placeholder={t('providerForm.billingModePlaceholder')} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="per_request">
-                {t('providerForm.billingModePerRequest')}
-              </SelectItem>
+              {modelType !== 'images' && (
+                <SelectItem value="per_request">
+                  {t('providerForm.billingModePerRequest')}
+                </SelectItem>
+              )}
+              {(modelType === 'images' || modelType === undefined) && (
+                <SelectItem value="per_image">
+                  {t('providerForm.billingModePerImage')}
+                </SelectItem>
+              )}
               <SelectItem value="token_flat">
                 {t('providerForm.billingModeTokenFlat')}
               </SelectItem>
-              <SelectItem value="token_tiered">
-                {t('providerForm.billingModeTokenTiered')}
-              </SelectItem>
+              {modelType !== 'images' && (
+                <SelectItem value="token_tiered">
+                  {t('providerForm.billingModeTokenTiered')}
+                </SelectItem>
+              )}
             </SelectContent>
           </Select>
         </div>
@@ -113,6 +126,19 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
             min={0}
             step="0.0001"
             {...register('per_request_price' as Path<TFormValues>)}
+          />
+        </div>
+      ) : billingMode === 'per_image' ? (
+        <div className="space-y-2">
+          <Label htmlFor="per_image_price">
+            {t('providerForm.pricePerImage')}
+          </Label>
+          <Input
+            id="per_image_price"
+            type="number"
+            min={0}
+            step="0.0001"
+            {...register('per_image_price' as Path<TFormValues>)}
           />
         </div>
       ) : billingMode === 'token_tiered' ? (

--- a/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
+++ b/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
@@ -45,10 +45,11 @@ interface ProviderModelBulkUpgradeDialogProps {
 
 interface FormData {
   new_target_model_name: string;
-  billing_mode: 'token_flat' | 'token_tiered' | 'per_request';
+  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
   input_price: string;
   output_price: string;
   per_request_price: string;
+  per_image_price: string;
   tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string }>;
 }
 
@@ -59,6 +60,7 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       input_price: '0',
       output_price: '0',
       per_request_price: '0',
+      per_image_price: '0',
       tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0' }],
     };
   }
@@ -71,6 +73,18 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       input_price: '0',
       output_price: '0',
       per_request_price: String(mapping.per_request_price ?? 0),
+      per_image_price: '0',
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0' }],
+    };
+  }
+
+  if (billingMode === 'per_image') {
+    return {
+      billing_mode: billingMode,
+      input_price: '0',
+      output_price: '0',
+      per_request_price: '0',
+      per_image_price: String(mapping.per_image_price ?? 0),
       tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0' }],
     };
   }
@@ -93,6 +107,7 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       input_price: '0',
       output_price: '0',
       per_request_price: '0',
+      per_image_price: '0',
       tiers,
     };
   }
@@ -102,6 +117,7 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
     input_price: String(mapping.input_price ?? 0),
     output_price: String(mapping.output_price ?? 0),
     per_request_price: '0',
+    per_image_price: '0',
     tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0' }],
   };
 }
@@ -133,6 +149,7 @@ export function ProviderModelBulkUpgradeDialog({
       input_price: '0',
       output_price: '0',
       per_request_price: '0',
+      per_image_price: '0',
       tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0' }],
     },
   });
@@ -168,11 +185,14 @@ export function ProviderModelBulkUpgradeDialog({
       input_price: null,
       output_price: null,
       per_request_price: null,
+      per_image_price: null,
       tiered_pricing: null,
     };
 
     if (data.billing_mode === 'per_request') {
       payload.per_request_price = Number(data.per_request_price.trim() || '0');
+    } else if (data.billing_mode === 'per_image') {
+      payload.per_image_price = Number(data.per_image_price.trim() || '0');
     } else if (data.billing_mode === 'token_tiered') {
       payload.tiered_pricing = (data.tiers || []).map((tier) => ({
         max_input_tokens: tier.max_input_tokens.trim() ? Number(tier.max_input_tokens.trim()) : null,
@@ -227,6 +247,7 @@ export function ProviderModelBulkUpgradeDialog({
                         inputPrice={mapping.input_price}
                         outputPrice={mapping.output_price}
                         perRequestPrice={mapping.per_request_price}
+                        perImagePrice={mapping.per_image_price}
                         tieredPricing={mapping.tiered_pricing}
                       />
                     </TableCell>

--- a/frontend/src/lib/__tests__/billing.test.ts
+++ b/frontend/src/lib/__tests__/billing.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { getBillingModesForModelType, buildBillingSubmitData } from '../billing';
+
+describe('getBillingModesForModelType', () => {
+  it('chat model has token_flat, token_tiered, per_request but not per_image', () => {
+    const modes = getBillingModesForModelType('chat');
+    expect(modes).toContain('token_flat');
+    expect(modes).toContain('token_tiered');
+    expect(modes).toContain('per_request');
+    expect(modes).not.toContain('per_image');
+  });
+
+  it('embedding model has same modes as chat', () => {
+    const modes = getBillingModesForModelType('embedding');
+    expect(modes).toContain('token_flat');
+    expect(modes).toContain('token_tiered');
+    expect(modes).toContain('per_request');
+    expect(modes).not.toContain('per_image');
+  });
+
+  it('images model has per_image and token_flat only', () => {
+    const modes = getBillingModesForModelType('images');
+    expect(modes).toContain('per_image');
+    expect(modes).toContain('token_flat');
+    expect(modes).not.toContain('per_request');
+    expect(modes).not.toContain('token_tiered');
+  });
+
+  it('undefined model type returns all modes', () => {
+    const modes = getBillingModesForModelType(undefined);
+    expect(modes).toContain('per_request');
+    expect(modes).toContain('per_image');
+    expect(modes).toContain('token_flat');
+    expect(modes).toContain('token_tiered');
+  });
+
+  it('speech model type returns all modes (not a billing type)', () => {
+    const modes = getBillingModesForModelType('speech');
+    expect(modes).toContain('per_request');
+    expect(modes).toContain('per_image');
+    expect(modes).toContain('token_flat');
+    expect(modes).toContain('token_tiered');
+  });
+});
+
+describe('buildBillingSubmitData', () => {
+  const baseValues = {
+    billing_mode: 'token_flat' as const,
+    input_price: '5.0',
+    output_price: '15.0',
+    per_request_price: '0.05',
+    per_image_price: '0.04',
+    tiers: [{ max_input_tokens: '32768', input_price: '1.0', output_price: '2.0' }],
+  };
+
+  it('non-billing model type returns all nulls', () => {
+    const result = buildBillingSubmitData(baseValues, false);
+    expect(result.billing_mode).toBeNull();
+    expect(result.input_price).toBeNull();
+    expect(result.output_price).toBeNull();
+    expect(result.per_request_price).toBeNull();
+    expect(result.per_image_price).toBeNull();
+    expect(result.tiered_pricing).toBeNull();
+  });
+
+  it('token_flat sets input/output price and nullifies others', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'token_flat' },
+      true,
+    );
+    expect(result.billing_mode).toBe('token_flat');
+    expect(result.input_price).toBe(5.0);
+    expect(result.output_price).toBe(15.0);
+    expect(result.per_request_price).toBeNull();
+    expect(result.per_image_price).toBeNull();
+    expect(result.tiered_pricing).toBeNull();
+  });
+
+  it('per_request sets per_request_price and nullifies others', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'per_request' },
+      true,
+    );
+    expect(result.billing_mode).toBe('per_request');
+    expect(result.per_request_price).toBe(0.05);
+    expect(result.per_image_price).toBeNull();
+    expect(result.input_price).toBeNull();
+    expect(result.output_price).toBeNull();
+    expect(result.tiered_pricing).toBeNull();
+  });
+
+  it('per_image sets per_image_price and nullifies others', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'per_image' },
+      true,
+    );
+    expect(result.billing_mode).toBe('per_image');
+    expect(result.per_image_price).toBe(0.04);
+    expect(result.per_request_price).toBeNull();
+    expect(result.input_price).toBeNull();
+    expect(result.output_price).toBeNull();
+    expect(result.tiered_pricing).toBeNull();
+  });
+
+  it('token_tiered builds tiered_pricing and nullifies others', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'token_tiered' },
+      true,
+    );
+    expect(result.billing_mode).toBe('token_tiered');
+    expect(result.tiered_pricing).toEqual([
+      { max_input_tokens: 32768, input_price: 1.0, output_price: 2.0 },
+    ]);
+    expect(result.per_request_price).toBeNull();
+    expect(result.per_image_price).toBeNull();
+    expect(result.input_price).toBeNull();
+    expect(result.output_price).toBeNull();
+  });
+
+  it('token_tiered with empty max_input_tokens sets null', () => {
+    const result = buildBillingSubmitData(
+      {
+        ...baseValues,
+        billing_mode: 'token_tiered',
+        tiers: [{ max_input_tokens: '', input_price: '3.0', output_price: '4.0' }],
+      },
+      true,
+    );
+    expect(result.tiered_pricing).toEqual([
+      { max_input_tokens: null, input_price: 3.0, output_price: 4.0 },
+    ]);
+  });
+
+  it('token_flat with empty input_price defaults to 0', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'token_flat', input_price: '', output_price: '' },
+      true,
+    );
+    expect(result.input_price).toBe(0);
+    expect(result.output_price).toBe(0);
+  });
+
+  it('per_request with empty price defaults to 0', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'per_request', per_request_price: '' },
+      true,
+    );
+    expect(result.per_request_price).toBe(0);
+  });
+
+  it('per_image with empty price defaults to 0', () => {
+    const result = buildBillingSubmitData(
+      { ...baseValues, billing_mode: 'per_image', per_image_price: '' },
+      true,
+    );
+    expect(result.per_image_price).toBe(0);
+  });
+});

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -50,6 +50,7 @@ export async function getLogCostStats(
     ? {
         start_time: params.start_time,
         end_time: params.end_time,
+        timeline: params.timeline,
         requested_model: params.requested_model,
         provider_id: params.provider_id,
         api_key_id: params.api_key_id,

--- a/frontend/src/lib/billing.ts
+++ b/frontend/src/lib/billing.ts
@@ -1,0 +1,121 @@
+/**
+ * Billing utility functions for model type-specific billing mode filtering
+ * and billing submit data construction.
+ */
+
+export type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
+
+/**
+ * Returns the allowed billing modes for a given model type.
+ * - chat / embedding: token_flat, token_tiered, per_request
+ * - images: per_image, token_flat
+ * - undefined (no model type): all modes (for backwards compat)
+ */
+export function getBillingModesForModelType(modelType?: string): BillingMode[] {
+  if (modelType === 'images') {
+    return ['per_image', 'token_flat'];
+  }
+  if (modelType === 'chat' || modelType === 'embedding') {
+    return ['per_request', 'token_flat', 'token_tiered'];
+  }
+  // No model type specified → show all (e.g. in bulk upgrade dialog)
+  return ['per_request', 'per_image', 'token_flat', 'token_tiered'];
+}
+
+export interface BillingSubmitData {
+  billing_mode: BillingMode | null;
+  input_price: number | null;
+  output_price: number | null;
+  per_request_price: number | null;
+  per_image_price: number | null;
+  tiered_pricing: Array<{
+    max_input_tokens: number | null;
+    input_price: number;
+    output_price: number;
+  }> | null;
+}
+
+interface BillingFormValues {
+  billing_mode: BillingMode;
+  input_price: string;
+  output_price: string;
+  per_request_price: string;
+  per_image_price: string;
+  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string }>;
+}
+
+/**
+ * Builds billing submit data from form values.
+ * Returns null-ed fields for billing modes that don't apply.
+ */
+export function buildBillingSubmitData(
+  values: BillingFormValues,
+  supportsBilling: boolean,
+): BillingSubmitData {
+  if (!supportsBilling) {
+    return {
+      billing_mode: null,
+      input_price: null,
+      output_price: null,
+      per_request_price: null,
+      per_image_price: null,
+      tiered_pricing: null,
+    };
+  }
+
+  const mode = values.billing_mode;
+
+  if (mode === 'per_request') {
+    const perReq = values.per_request_price.trim();
+    return {
+      billing_mode: mode,
+      per_request_price: perReq ? Number(perReq) : 0,
+      per_image_price: null,
+      input_price: null,
+      output_price: null,
+      tiered_pricing: null,
+    };
+  }
+
+  if (mode === 'per_image') {
+    const perImg = values.per_image_price.trim();
+    return {
+      billing_mode: mode,
+      per_image_price: perImg ? Number(perImg) : 0,
+      per_request_price: null,
+      input_price: null,
+      output_price: null,
+      tiered_pricing: null,
+    };
+  }
+
+  if (mode === 'token_tiered') {
+    return {
+      billing_mode: mode,
+      tiered_pricing: (values.tiers || []).map((t) => {
+        const maxStr = t.max_input_tokens.trim();
+        return {
+          max_input_tokens: maxStr === '' ? null : Number(maxStr),
+          input_price: Number(t.input_price || '0'),
+          output_price: Number(t.output_price || '0'),
+        };
+      }),
+      per_request_price: null,
+      per_image_price: null,
+      input_price: null,
+      output_price: null,
+    };
+  }
+
+  // token_flat
+  const inputPrice = values.input_price.trim();
+  const outputPrice = values.output_price.trim();
+  return {
+    billing_mode: mode,
+    input_price: inputPrice ? Number(inputPrice) : 0,
+    output_price: outputPrice ? Number(outputPrice) : 0,
+    per_request_price: null,
+    per_image_price: null,
+    tiered_pricing: null,
+  };
+}

--- a/frontend/src/types/api-key.ts
+++ b/frontend/src/types/api-key.ts
@@ -11,6 +11,7 @@ export interface ApiKey {
   is_active: boolean;
   created_at: string;
   last_used_at?: string | null;
+  monthly_cost?: number | null; // Current month's total cost (USD)
 }
 
 /** Create API Key Request */

--- a/frontend/src/types/log.ts
+++ b/frontend/src/types/log.ts
@@ -54,6 +54,8 @@ export interface LogQueryParams {
   // Time range
   start_time?: string;
   end_time?: string;
+  // Relative time range preset (server-side resolved). Ignored when start_time is set.
+  timeline?: '1h' | '3h' | '6h' | '12h' | '24h' | '1w';
 
   // Client timezone offset minutes for stats bucketing (UTC to local)
   tz_offset_minutes?: number;

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -20,6 +20,15 @@ export interface ModelMapping {
   // Pricing (USD per 1,000,000 tokens)
   input_price?: number | null;
   output_price?: number | null;
+  // Model-level billing mode
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  per_request_price?: number | null;
+  per_image_price?: number | null;
+  tiered_pricing?: Array<{
+    max_input_tokens?: number | null;
+    input_price: number;
+    output_price: number;
+  }> | null;
   provider_count?: number;            // Associated provider count
   active_provider_count?: number;     // Associated active provider count
   providers?: ModelMappingProvider[]; // Detail contains provider list
@@ -40,10 +49,12 @@ export interface ModelMappingProvider {
   // Provider override pricing (USD per 1,000,000 tokens)
   input_price?: number | null;
   output_price?: number | null;
-  // Billing mode: token_flat / token_tiered / per_request
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | null;
+  // Billing mode: token_flat / token_tiered / per_request / per_image
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
   // Per-request fixed price (USD), used when billing_mode == per_request
   per_request_price?: number | null;
+  // Per-image price (USD), used when billing_mode == per_image
+  per_image_price?: number | null;
   // Tiered pricing config, used when billing_mode == token_tiered
   tiered_pricing?: Array<{
     max_input_tokens?: number | null;
@@ -66,6 +77,14 @@ export interface ModelMappingCreate {
   is_active?: boolean;
   input_price?: number | null;
   output_price?: number | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  per_request_price?: number | null;
+  per_image_price?: number | null;
+  tiered_pricing?: Array<{
+    max_input_tokens?: number | null;
+    input_price: number;
+    output_price: number;
+  }> | null;
 }
 
 /** Update Model Mapping Request */
@@ -76,6 +95,14 @@ export interface ModelMappingUpdate {
   is_active?: boolean;
   input_price?: number | null;
   output_price?: number | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  per_request_price?: number | null;
+  per_image_price?: number | null;
+  tiered_pricing?: Array<{
+    max_input_tokens?: number | null;
+    input_price: number;
+    output_price: number;
+  }> | null;
 }
 
 /** Create Model-Provider Mapping Request */
@@ -86,8 +113,9 @@ export interface ModelMappingProviderCreate {
   provider_rules?: RuleSet;
   input_price?: number | null;
   output_price?: number | null;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request';
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
   per_request_price?: number | null;
+  per_image_price?: number | null;
   tiered_pricing?: Array<{
     max_input_tokens?: number | null;
     input_price: number;
@@ -104,8 +132,9 @@ export interface ModelMappingProviderUpdate {
   provider_rules?: RuleSet | null;
   input_price?: number | null;
   output_price?: number | null;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
   per_request_price?: number | null;
+  per_image_price?: number | null;
   tiered_pricing?: Array<{
     max_input_tokens?: number | null;
     input_price: number;
@@ -121,10 +150,11 @@ export interface ModelProviderBulkUpgradeRequest {
   provider_id: number;
   current_target_model_name: string;
   new_target_model_name: string;
-  billing_mode: 'token_flat' | 'token_tiered' | 'per_request';
+  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
   input_price?: number | null;
   output_price?: number | null;
   per_request_price?: number | null;
+  per_image_price?: number | null;
   tiered_pricing?: Array<{
     max_input_tokens?: number | null;
     input_price: number;
@@ -163,8 +193,9 @@ export interface ModelProviderExport {
   provider_rules?: RuleSet | null;
   input_price?: number | null;
   output_price?: number | null;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
   per_request_price?: number | null;
+  per_image_price?: number | null;
   tiered_pricing?: Array<{
     max_input_tokens?: number | null;
     input_price: number;
@@ -211,10 +242,11 @@ export interface ModelMatchProvider {
   protocol: ProtocolType;
   priority: number;
   weight: number;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
   input_price?: number | null;
   output_price?: number | null;
   per_request_price?: number | null;
+  per_image_price?: number | null;
   tiered_pricing?: Array<{
     max_input_tokens?: number | null;
     input_price: number;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
This PR introduces bidirectional protocol conversion between OpenAI and Anthropic API formats, allowing the proxy service to handle requests where the user's protocol differs from the supplier's protocol.

### Key Changes:

- **New Protocol Conversion Module**: Added `backend/app/common/protocol_conversion.py` which handles:
    - Request body and path transformation (e.g., `/v1/chat/completions` <-> `/v1/messages`).
    - Static response body transformation.
    - SSE (Server-Sent Events) stream transformation for real-time completions.
- **Proxy Service Integration**: Updated `ProxyService` to detect protocol mismatches and automatically apply the necessary conversions before sending requests to suppliers and before returning responses to users.
- **Dependencies**: Added `litellm` to `pyproject.toml` and `requirements.txt` to leverage its internal transformation utilities for robust protocol mapping.
- **Testing**: 
    - Added `test_protocol_conversion.py` with comprehensive unit tests for request, response, and stream mapping.
    - Updated `test_proxy_service_protocol_matching.py` to reflect the new conversion capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monthly cost tracking for API keys.
  * Introduced per-image billing mode alongside existing pricing options.
  * Added relative time range presets (1h, 3h, 6h, 12h, 24h, 1w) for log and cost statistics queries.
  * Enhanced billing displays to support per-image pricing visualization.

* **Tests**
  * Added comprehensive billing validation and per-image pricing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->