### PR TITLE
模型价格问题 (vibe-kanban 9c6c7f30)

### DIFF
--- a/backend/app/common/costs.py
+++ b/backend/app/common/costs.py
@@ -20,6 +20,7 @@ BILLING_MODE_TOKEN_FLAT = "token_flat"
 BILLING_MODE_TOKEN_TIERED = "token_tiered"
 BILLING_MODE_PER_REQUEST = "per_request"
 BILLING_MODE_PER_IMAGE = "per_image"
+BILLING_MODE_INHERIT_MODEL_DEFAULT = "inherit_model_default"
 
 
 _ONE_MILLION = Decimal("1000000")
@@ -208,8 +209,19 @@ def resolve_billing(
     Priority: provider billing_mode > model billing_mode > token_flat fallback.
     Within token_flat, price resolution: provider override > model fallback > zero.
     """
+    # When inherit_model_default, ignore all provider pricing
+    if provider_billing_mode == BILLING_MODE_INHERIT_MODEL_DEFAULT:
+        provider_input_price = None
+        provider_output_price = None
+        provider_per_request_price = None
+        provider_per_image_price = None
+        provider_tiered_pricing = None
+        provider_cache_billing_enabled = None
+        provider_cached_input_price = None
+        provider_cached_output_price = None
+
     # Determine effective billing source
-    if provider_billing_mode:
+    if provider_billing_mode and provider_billing_mode != BILLING_MODE_INHERIT_MODEL_DEFAULT:
         mode = provider_billing_mode
         eff_per_request_price = provider_per_request_price
         eff_per_image_price = provider_per_image_price

--- a/backend/app/repositories/sqlalchemy/model_repo.py
+++ b/backend/app/repositories/sqlalchemy/model_repo.py
@@ -59,10 +59,13 @@ class SQLAlchemyModelRepository(ModelRepository):
             per_request_price=float(entity.per_request_price) if entity.per_request_price is not None else None,
             per_image_price=float(entity.per_image_price) if entity.per_image_price is not None else None,
             tiered_pricing=entity.tiered_pricing,
+            cache_billing_enabled=entity.cache_billing_enabled,
+            cached_input_price=float(entity.cached_input_price) if entity.cached_input_price is not None else None,
+            cached_output_price=float(entity.cached_output_price) if entity.cached_output_price is not None else None,
             created_at=ensure_utc(entity.created_at),
             updated_at=ensure_utc(entity.updated_at),
         )
-    
+
     def _provider_mapping_to_domain(
         self,
         entity: ModelMappingProviderORM,
@@ -90,13 +93,16 @@ class SQLAlchemyModelRepository(ModelRepository):
             if entity.per_image_price is not None
             else None,
             tiered_pricing=entity.tiered_pricing,
+            cache_billing_enabled=entity.cache_billing_enabled,
+            cached_input_price=float(entity.cached_input_price) if entity.cached_input_price is not None else None,
+            cached_output_price=float(entity.cached_output_price) if entity.cached_output_price is not None else None,
             priority=entity.priority,
             weight=entity.weight,
             is_active=entity.is_active,
             created_at=ensure_utc(entity.created_at),
             updated_at=ensure_utc(entity.updated_at),
         )
-    
+
     # ============ Model Mapping Operations ============
     
     async def create_mapping(self, data: ModelMappingCreate) -> ModelMapping:
@@ -110,6 +116,17 @@ class SQLAlchemyModelRepository(ModelRepository):
             is_active=data.is_active,
             input_price=data.input_price,
             output_price=data.output_price,
+            billing_mode=data.billing_mode,
+            per_request_price=data.per_request_price,
+            per_image_price=data.per_image_price,
+            tiered_pricing=[
+                t.model_dump() for t in (data.tiered_pricing or [])
+            ]
+            if data.tiered_pricing is not None
+            else None,
+            cache_billing_enabled=data.cache_billing_enabled or False,
+            cached_input_price=data.cached_input_price,
+            cached_output_price=data.cached_output_price,
         )
         self.session.add(entity)
         await self.session.commit()

--- a/backend/tests/unit/test_common/test_inherit_model_default.py
+++ b/backend/tests/unit/test_common/test_inherit_model_default.py
@@ -1,0 +1,270 @@
+"""
+Tests for inherit_model_default billing mode in resolve_billing.
+
+When a provider has billing_mode="inherit_model_default", it should
+behave as if the provider has no billing_mode — falling back to the
+model's billing configuration.
+"""
+
+import pytest
+from app.common.costs import (
+    BILLING_MODE_PER_IMAGE,
+    BILLING_MODE_PER_REQUEST,
+    BILLING_MODE_TOKEN_FLAT,
+    BILLING_MODE_TOKEN_TIERED,
+    PRICE_SOURCE_DEFAULT_ZERO,
+    PRICE_SOURCE_MODEL_FALLBACK,
+    calculate_cost_from_billing,
+    resolve_billing,
+)
+
+
+class TestInheritModelDefaultFallback:
+    """Test that inherit_model_default falls back to model billing."""
+
+    def test_inherit_falls_back_to_model_token_flat(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=2.0,
+            model_output_price=3.0,
+            model_billing_mode="token_flat",
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.input_price == 2.0
+        assert billing.output_price == 3.0
+
+    def test_inherit_falls_back_to_model_token_tiered(self):
+        tiers = [
+            {"max_input_tokens": 5000, "input_price": 1.0, "output_price": 2.0},
+            {"max_input_tokens": None, "input_price": 3.0, "output_price": 4.0},
+        ]
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=None,
+            model_output_price=None,
+            model_billing_mode="token_tiered",
+            model_tiered_pricing=tiers,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_TIERED
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.input_price == 1.0
+        assert billing.output_price == 2.0
+
+    def test_inherit_falls_back_to_model_token_tiered_second_tier(self):
+        tiers = [
+            {"max_input_tokens": 5000, "input_price": 1.0, "output_price": 2.0},
+            {"max_input_tokens": None, "input_price": 3.0, "output_price": 4.0},
+        ]
+        billing = resolve_billing(
+            input_tokens=10000,
+            model_input_price=None,
+            model_output_price=None,
+            model_billing_mode="token_tiered",
+            model_tiered_pricing=tiers,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_TIERED
+        assert billing.input_price == 3.0
+        assert billing.output_price == 4.0
+
+    def test_inherit_falls_back_to_model_per_request(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="per_request",
+            model_per_request_price=0.05,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_REQUEST
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.per_request_price == 0.05
+
+    def test_inherit_falls_back_to_model_per_image(self):
+        billing = resolve_billing(
+            input_tokens=0,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="per_image",
+            model_per_image_price=0.04,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_per_image_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_PER_IMAGE
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.per_image_price == 0.04
+
+    def test_inherit_with_model_cache_billing(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode="token_flat",
+            model_cache_billing_enabled=True,
+            model_cached_input_price=1.0,
+            model_cached_output_price=3.0,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.cache_billing_enabled is True
+        assert billing.cached_input_price == 1.0
+        assert billing.cached_output_price == 3.0
+
+    def test_inherit_ignores_provider_prices(self):
+        """Even if provider has input/output prices, inherit mode should use model prices."""
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=2.0,
+            model_output_price=3.0,
+            model_billing_mode="token_flat",
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=10.0,
+            provider_output_price=20.0,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_MODEL_FALLBACK
+        assert billing.input_price == 2.0
+        assert billing.output_price == 3.0
+
+    def test_inherit_with_no_model_billing(self):
+        """When both inherit and no model billing → default to token_flat with zero."""
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=None,
+            model_output_price=None,
+            model_billing_mode=None,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.billing_mode == BILLING_MODE_TOKEN_FLAT
+        assert billing.price_source == PRICE_SOURCE_DEFAULT_ZERO
+        assert billing.input_price == 0.0
+        assert billing.output_price == 0.0
+
+
+class TestInheritModelDefaultCostCalculation:
+    """End-to-end cost calculation with inherit mode."""
+
+    def test_inherit_cost_calculation_token_flat(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode="token_flat",
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        cost = calculate_cost_from_billing(
+            input_tokens=1_000_000,
+            output_tokens=500_000,
+            billing=billing,
+        )
+        assert cost.input_cost == 5.0
+        assert cost.output_cost == 7.5
+        assert cost.total_cost == 12.5
+
+    def test_inherit_cost_calculation_per_request(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="per_request",
+            model_per_request_price=0.01,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        cost = calculate_cost_from_billing(
+            input_tokens=1000,
+            output_tokens=500,
+            billing=billing,
+        )
+        assert cost.total_cost == 0.01
+
+    def test_inherit_cost_calculation_per_image(self):
+        billing = resolve_billing(
+            input_tokens=0,
+            model_input_price=0.0,
+            model_output_price=0.0,
+            model_billing_mode="per_image",
+            model_per_image_price=0.04,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_per_image_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        cost = calculate_cost_from_billing(
+            input_tokens=0,
+            output_tokens=0,
+            billing=billing,
+            image_count=3,
+        )
+        assert cost.total_cost == pytest.approx(0.12)
+
+    def test_inherit_cost_calculation_with_cache(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode="token_flat",
+            model_cache_billing_enabled=True,
+            model_cached_input_price=1.0,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        cost = calculate_cost_from_billing(
+            input_tokens=1_000_000,
+            output_tokens=500_000,
+            billing=billing,
+            cached_input_tokens=300_000,
+        )
+        # non-cached input: 700k/1M * 5 = 3.5
+        # cached input: 300k/1M * 1 = 0.3
+        # output: 500k/1M * 15 = 7.5
+        assert cost.input_cost == 3.8
+        assert cost.cached_input_cost == 0.3
+        assert cost.output_cost == 7.5
+        assert cost.total_cost == 11.3

--- a/backend/tests/unit/test_common/test_inherit_validation.py
+++ b/backend/tests/unit/test_common/test_inherit_validation.py
@@ -1,0 +1,69 @@
+"""
+Tests for inherit_model_default validation in domain models.
+
+- Provider-level DTOs should accept inherit_model_default without pricing fields.
+- Model-level DTO should reject inherit_model_default.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.domain.model import (
+    ModelMappingCreate,
+    ModelMappingProviderCreate,
+    ModelProviderBulkUpgradeRequest,
+)
+
+
+class TestProviderCreateAcceptsInherit:
+    """ModelMappingProviderCreate accepts inherit_model_default."""
+
+    def test_provider_create_accepts_inherit(self):
+        data = ModelMappingProviderCreate(
+            requested_model="test-model",
+            provider_id=1,
+            target_model_name="gpt-4",
+            billing_mode="inherit_model_default",
+        )
+        assert data.billing_mode == "inherit_model_default"
+
+    def test_provider_create_inherit_no_prices_needed(self):
+        """Should succeed without any pricing fields."""
+        data = ModelMappingProviderCreate(
+            requested_model="test-model",
+            provider_id=1,
+            target_model_name="gpt-4",
+            billing_mode="inherit_model_default",
+            input_price=None,
+            output_price=None,
+            per_request_price=None,
+            per_image_price=None,
+            tiered_pricing=None,
+        )
+        assert data.billing_mode == "inherit_model_default"
+        assert data.input_price is None
+        assert data.output_price is None
+
+
+class TestBulkUpgradeAcceptsInherit:
+    """ModelProviderBulkUpgradeRequest accepts inherit_model_default."""
+
+    def test_bulk_upgrade_accepts_inherit(self):
+        data = ModelProviderBulkUpgradeRequest(
+            provider_id=1,
+            current_target_model_name="gpt-4",
+            new_target_model_name="gpt-4-turbo",
+            billing_mode="inherit_model_default",
+        )
+        assert data.billing_mode == "inherit_model_default"
+
+
+class TestModelCreateRejectsInherit:
+    """ModelMappingCreate should NOT accept inherit_model_default."""
+
+    def test_model_create_rejects_inherit(self):
+        with pytest.raises(ValidationError, match="inherit_model_default"):
+            ModelMappingCreate(
+                requested_model="test-model",
+                billing_mode="inherit_model_default",
+            )

--- a/backend/tests/unit/test_repositories/test_model_repo_create.py
+++ b/backend/tests/unit/test_repositories/test_model_repo_create.py
@@ -1,0 +1,147 @@
+"""
+Tests for create_mapping in SQLAlchemyModelRepository.
+
+Verifies that all pricing fields (billing_mode, tiered_pricing,
+per_request_price, per_image_price, cache_billing_enabled,
+cached_input_price, cached_output_price) are correctly persisted
+when creating a model mapping.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.domain.model import ModelMappingCreate, TokenTierPrice
+from app.repositories.sqlalchemy.model_repo import SQLAlchemyModelRepository
+
+
+@pytest_asyncio.fixture
+async def model_repo(db_session):
+    return SQLAlchemyModelRepository(db_session)
+
+
+@pytest.mark.asyncio
+class TestCreateMappingPersistsPricingFields:
+    """Regression tests for the create_mapping bug fix."""
+
+    async def test_create_mapping_persists_token_flat(self, model_repo):
+        data = ModelMappingCreate(
+            requested_model="test-flat",
+            billing_mode="token_flat",
+            input_price=5.0,
+            output_price=15.0,
+        )
+        result = await model_repo.create_mapping(data)
+        assert result.billing_mode == "token_flat"
+        assert result.input_price == 5.0
+        assert result.output_price == 15.0
+
+    async def test_create_mapping_persists_token_tiered(self, model_repo):
+        data = ModelMappingCreate(
+            requested_model="test-tiered",
+            billing_mode="token_tiered",
+            tiered_pricing=[
+                TokenTierPrice(
+                    max_input_tokens=32768,
+                    input_price=1.0,
+                    output_price=2.0,
+                ),
+                TokenTierPrice(
+                    max_input_tokens=None,
+                    input_price=3.0,
+                    output_price=4.0,
+                    cached_input_price=0.5,
+                ),
+            ],
+        )
+        result = await model_repo.create_mapping(data)
+        assert result.billing_mode == "token_tiered"
+        assert result.tiered_pricing is not None
+        assert len(result.tiered_pricing) == 2
+        # Tiered pricing is stored as dicts
+        tier0 = result.tiered_pricing[0]
+        tier1 = result.tiered_pricing[1]
+        if isinstance(tier0, dict):
+            assert tier0["max_input_tokens"] == 32768
+            assert tier0["input_price"] == 1.0
+            assert tier0["output_price"] == 2.0
+            assert tier1["max_input_tokens"] is None
+            assert tier1["input_price"] == 3.0
+            assert tier1["output_price"] == 4.0
+            assert tier1["cached_input_price"] == 0.5
+        else:
+            assert tier0.max_input_tokens == 32768
+            assert tier0.input_price == 1.0
+            assert tier1.input_price == 3.0
+
+    async def test_create_mapping_persists_per_request(self, model_repo):
+        data = ModelMappingCreate(
+            requested_model="test-per-request",
+            billing_mode="per_request",
+            per_request_price=0.05,
+        )
+        result = await model_repo.create_mapping(data)
+        assert result.billing_mode == "per_request"
+        assert result.per_request_price == 0.05
+
+    async def test_create_mapping_persists_per_image(self, model_repo):
+        data = ModelMappingCreate(
+            requested_model="test-per-image",
+            model_type="images",
+            billing_mode="per_image",
+            per_image_price=0.04,
+        )
+        result = await model_repo.create_mapping(data)
+        assert result.billing_mode == "per_image"
+        assert result.per_image_price == 0.04
+
+    async def test_create_mapping_persists_cache_billing(self, model_repo):
+        data = ModelMappingCreate(
+            requested_model="test-cache",
+            billing_mode="token_flat",
+            input_price=5.0,
+            output_price=15.0,
+            cache_billing_enabled=True,
+            cached_input_price=1.0,
+            cached_output_price=3.0,
+        )
+        result = await model_repo.create_mapping(data)
+        assert result.billing_mode == "token_flat"
+        assert result.cache_billing_enabled is True
+        assert result.cached_input_price == 1.0
+        assert result.cached_output_price == 3.0
+
+    async def test_create_mapping_roundtrip_get(self, model_repo):
+        """Create and then get the mapping to verify persistence."""
+        data = ModelMappingCreate(
+            requested_model="test-roundtrip",
+            billing_mode="token_tiered",
+            tiered_pricing=[
+                TokenTierPrice(
+                    max_input_tokens=32768,
+                    input_price=1.0,
+                    output_price=2.0,
+                ),
+            ],
+            cache_billing_enabled=True,
+            cached_input_price=0.5,
+        )
+        await model_repo.create_mapping(data)
+
+        fetched = await model_repo.get_mapping("test-roundtrip")
+        assert fetched is not None
+        assert fetched.billing_mode == "token_tiered"
+        assert fetched.tiered_pricing is not None
+        assert len(fetched.tiered_pricing) == 1
+        assert fetched.cache_billing_enabled is True
+        assert fetched.cached_input_price == 0.5
+
+    async def test_create_mapping_no_billing_mode(self, model_repo):
+        """When no billing_mode is set, fields should be None."""
+        data = ModelMappingCreate(
+            requested_model="test-no-billing",
+        )
+        result = await model_repo.create_mapping(data)
+        assert result.billing_mode is None
+        assert result.tiered_pricing is None
+        assert result.per_request_price is None
+        assert result.per_image_price is None

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -457,7 +457,8 @@
         "tieredPreview": "Tiered: {preview}{more}",
         "tieredPreviewMore": " (+{count})",
         "tieredEntry": "≤{max}: {input}/{output}",
-        "cacheSuffix": "Cached: {cachedInput}/{cachedOutput}"
+        "cacheSuffix": "Cached: {cachedInput}/{cachedOutput}",
+        "inheritModel": "Inherit model default"
       }
     },
     "providerForm": {
@@ -492,6 +493,8 @@
       "billingModePerImage": "Per image",
       "billingModeTokenFlat": "Per token (flat)",
       "billingModeTokenTiered": "Per token (tiered by input tokens)",
+      "billingModeInherit": "Inherit model default",
+      "inheritHint": "Uses model-level pricing. No provider-level override.",
       "pricePerRequest": "Price (USD / request)",
       "pricePerImage": "Price (USD / image)",
       "tieredHint": "Choose the tier by input tokens, then bill input/output tokens separately by that tier’s prices.",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -457,7 +457,8 @@
         "tieredPreview": "分档：{preview}{more}",
         "tieredPreviewMore": " (+{count})",
         "tieredEntry": "≤{max}: {input}/{output}",
-        "cacheSuffix": "缓存：{cachedInput}/{cachedOutput}"
+        "cacheSuffix": "缓存：{cachedInput}/{cachedOutput}",
+        "inheritModel": "继承模型默认值"
       }
     },
     "providerForm": {
@@ -492,6 +493,8 @@
       "billingModePerImage": "按图片计费",
       "billingModeTokenFlat": "按 token 计费（固定）",
       "billingModeTokenTiered": "按 token 计费（按输入 token 分档）",
+      "billingModeInherit": "继承模型默认值",
+      "inheritHint": "使用模型级别定价，不设置供应商级别价格覆盖。",
       "pricePerRequest": "价格（美元/请求）",
       "pricePerImage": "价格（美元/张）",
       "tieredHint": "先按输入 token 选档，再按档位价格分别计费输入/输出 token。",

--- a/frontend/src/components/models/BillingDisplay.tsx
+++ b/frontend/src/components/models/BillingDisplay.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
-type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null | undefined;
+type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default' | null | undefined;
 
 interface BillingTier {
   max_input_tokens?: number | null;
@@ -79,6 +79,10 @@ export function BillingDisplay({
     value === 0 ? t('detail.billingDisplay.free') : formatUsdCeil4(value);
 
   const mode = billingMode ?? 'token_flat';
+
+  if (mode === 'inherit_model_default') {
+    return <span className={cn('font-mono', className)}>{t('detail.billingDisplay.inheritModel')}</span>;
+  }
 
   let text = '';
   if (mode === 'per_request') {

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -216,7 +216,7 @@ export function ModelForm({
 
     if (supportsBilling) {
       const billingMode = data.billing_mode;
-      submitData.billing_mode = billingMode;
+      submitData.billing_mode = billingMode as ModelMappingCreate['billing_mode'];
       if (billingMode === 'per_request') {
         const perReq = data.per_request_price.trim();
         submitData.per_request_price = perReq ? Number(perReq) : 0;

--- a/frontend/src/components/models/ModelProviderBillingFields.tsx
+++ b/frontend/src/components/models/ModelProviderBillingFields.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/select';
 import type { ModelType } from '@/types';
 
-export type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
+export type BillingMode = 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default';
 
 interface TierInputValue {
   max_input_tokens: string;
@@ -53,6 +53,7 @@ interface ModelProviderBillingFieldsProps<TFormValues extends BillingFormValues>
   onLoadHistory?: () => void;
   showHistoryButton?: boolean;
   modelType?: ModelType;
+  showInheritOption?: boolean;
   cacheBillingEnabled: boolean;
   setCacheBillingEnabled: (enabled: boolean) => void;
 }
@@ -69,6 +70,7 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
   onLoadHistory,
   showHistoryButton = false,
   modelType,
+  showInheritOption = false,
   cacheBillingEnabled,
   setCacheBillingEnabled,
 }: ModelProviderBillingFieldsProps<TFormValues>) {
@@ -102,6 +104,11 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
               <SelectValue placeholder={t('providerForm.billingModePlaceholder')} />
             </SelectTrigger>
             <SelectContent>
+              {showInheritOption && (
+                <SelectItem value="inherit_model_default">
+                  {t('providerForm.billingModeInherit')}
+                </SelectItem>
+              )}
               {modelType !== 'images' && (
                 <SelectItem value="per_request">
                   {t('providerForm.billingModePerRequest')}
@@ -123,7 +130,7 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
             </SelectContent>
           </Select>
         </div>
-        {billingMode !== 'per_request' && billingMode !== 'per_image' && (
+        {billingMode !== 'per_request' && billingMode !== 'per_image' && billingMode !== 'inherit_model_default' && (
           <div className="flex items-center gap-2 h-9 shrink-0">
             <Switch
               checked={cacheBillingEnabled}
@@ -136,7 +143,11 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
         )}
       </div>
 
-      {billingMode === 'per_request' ? (
+      {billingMode === 'inherit_model_default' ? (
+        <p className="text-sm text-muted-foreground">
+          {t('providerForm.inheritHint')}
+        </p>
+      ) : billingMode === 'per_request' ? (
         <div className="space-y-2">
           <Label htmlFor="per_request_price">
             {t('providerForm.pricePerRequest')}

--- a/frontend/src/components/models/ModelProviderForm.tsx
+++ b/frontend/src/components/models/ModelProviderForm.tsx
@@ -79,7 +79,7 @@ interface FormData {
   provider_id: string;
   target_model_name: string;
   provider_rules: RuleSet | null;
-  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
+  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default';
   // token_flat
   input_price: string;
   output_price: string;
@@ -176,7 +176,8 @@ export function ModelProviderForm({
         | 'token_flat'
         | 'token_tiered'
         | 'per_request'
-        | 'per_image';
+        | 'per_image'
+        | 'inherit_model_default';
 
       reset({
         provider_id: String(mapping.provider_id),
@@ -420,7 +421,16 @@ export function ModelProviderForm({
 
       if (supportsBilling) {
         submitData.billing_mode = billingMode;
-        if (billingMode === 'per_request') {
+        if (billingMode === 'inherit_model_default') {
+          submitData.input_price = null;
+          submitData.output_price = null;
+          submitData.per_request_price = null;
+          submitData.per_image_price = null;
+          submitData.tiered_pricing = null;
+          submitData.cache_billing_enabled = null;
+          submitData.cached_input_price = null;
+          submitData.cached_output_price = null;
+        } else if (billingMode === 'per_request') {
           const perReq = data.per_request_price.trim();
           submitData.per_request_price = perReq ? Number(perReq) : 0;
           submitData.per_image_price = null;
@@ -473,7 +483,16 @@ export function ModelProviderForm({
 
       if (supportsBilling) {
         submitData.billing_mode = billingMode;
-        if (billingMode === 'per_request') {
+        if (billingMode === 'inherit_model_default') {
+          submitData.input_price = null;
+          submitData.output_price = null;
+          submitData.per_request_price = null;
+          submitData.per_image_price = null;
+          submitData.tiered_pricing = null;
+          submitData.cache_billing_enabled = null;
+          submitData.cached_input_price = null;
+          submitData.cached_output_price = null;
+        } else if (billingMode === 'per_request') {
           const perReq = data.per_request_price.trim();
           submitData.per_request_price = perReq ? Number(perReq) : 0;
           submitData.per_image_price = null;
@@ -619,6 +638,7 @@ export function ModelProviderForm({
               onLoadHistory={handleLoadPriceHistory}
               showHistoryButton
               modelType={modelType}
+              showInheritOption
               cacheBillingEnabled={cacheBillingEnabled}
               setCacheBillingEnabled={(value) => setValue('cache_billing_enabled', value)}
             />

--- a/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
+++ b/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
@@ -45,7 +45,7 @@ interface ProviderModelBulkUpgradeDialogProps {
 
 interface FormData {
   new_target_model_name: string;
-  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
+  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default';
   input_price: string;
   output_price: string;
   per_request_price: string;
@@ -72,6 +72,20 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
   }
 
   const billingMode = (mapping.billing_mode || 'token_flat') as FormData['billing_mode'];
+
+  if (billingMode === 'inherit_model_default') {
+    return {
+      billing_mode: 'inherit_model_default',
+      input_price: '0',
+      output_price: '0',
+      per_request_price: '0',
+      per_image_price: '0',
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      cache_billing_enabled: false,
+      cached_input_price: '',
+      cached_output_price: '',
+    };
+  }
 
   if (billingMode === 'per_request') {
     return {
@@ -215,7 +229,9 @@ export function ProviderModelBulkUpgradeDialog({
       cached_output_price: null,
     };
 
-    if (data.billing_mode === 'per_request') {
+    if (data.billing_mode === 'inherit_model_default') {
+      // All pricing fields already null from initialization
+    } else if (data.billing_mode === 'per_request') {
       payload.per_request_price = Number(data.per_request_price.trim() || '0');
     } else if (data.billing_mode === 'per_image') {
       payload.per_image_price = Number(data.per_image_price.trim() || '0');
@@ -311,6 +327,7 @@ export function ProviderModelBulkUpgradeDialog({
               tierFields={tierFields}
               appendTier={appendTier}
               removeTier={removeTier}
+              showInheritOption
               cacheBillingEnabled={watch('cache_billing_enabled')}
               setCacheBillingEnabled={(value) => setValue('cache_billing_enabled', value)}
             />

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -54,8 +54,8 @@ export interface ModelMappingProvider {
   // Provider override pricing (USD per 1,000,000 tokens)
   input_price?: number | null;
   output_price?: number | null;
-  // Billing mode: token_flat / token_tiered / per_request / per_image
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  // Billing mode: token_flat / token_tiered / per_request / per_image / inherit_model_default
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default' | null;
   // Per-request fixed price (USD), used when billing_mode == per_request
   per_request_price?: number | null;
   // Per-image price (USD), used when billing_mode == per_image
@@ -133,7 +133,7 @@ export interface ModelMappingProviderCreate {
   provider_rules?: RuleSet;
   input_price?: number | null;
   output_price?: number | null;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default';
   per_request_price?: number | null;
   per_image_price?: number | null;
   tiered_pricing?: Array<{
@@ -157,7 +157,7 @@ export interface ModelMappingProviderUpdate {
   provider_rules?: RuleSet | null;
   input_price?: number | null;
   output_price?: number | null;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default' | null;
   per_request_price?: number | null;
   per_image_price?: number | null;
   tiered_pricing?: Array<{
@@ -180,7 +180,7 @@ export interface ModelProviderBulkUpgradeRequest {
   provider_id: number;
   current_target_model_name: string;
   new_target_model_name: string;
-  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image';
+  billing_mode: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default';
   input_price?: number | null;
   output_price?: number | null;
   per_request_price?: number | null;
@@ -228,7 +228,7 @@ export interface ModelProviderExport {
   provider_rules?: RuleSet | null;
   input_price?: number | null;
   output_price?: number | null;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default' | null;
   per_request_price?: number | null;
   per_image_price?: number | null;
   tiered_pricing?: Array<{
@@ -282,7 +282,7 @@ export interface ModelMatchProvider {
   protocol: ProtocolType;
   priority: number;
   weight: number;
-  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
+  billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default' | null;
   input_price?: number | null;
   output_price?: number | null;
   per_request_price?: number | null;


### PR DESCRIPTION
1. 在新增模型的时候，设置了分层的模型价格，但是保存后却显示为 free，重新编辑发现值没有录入进去，二次更新后才有值
2. 在模型和供应商绑定的时候，模型价格增加一种新模式：“继承模型默认值”，当选择这个值之后，当前供应商的这个模型价格按照模型上设置的价格来计费

注意影响范围：

1. 针对图片、对话、嵌入模型都要做好处理
2. 处理好模型页面、模型和供应商绑定页面，这两个页面的列表，详情展示，请求响应日志记录的准确性
3. 不要漏掉供应商页面的 In-use Models 中的模型一键升级功能

请为本次实现的功能编写完备的单元测试，确保测试用例覆盖基本的功能，同时确保所有测试用例运行通过后再交付。