### PR TITLE
feat: implement protocol conversion between OpenAI and Anthropic

### DIFF
--- a/frontend/src/components/common/JsonViewer.tsx
+++ b/frontend/src/components/common/JsonViewer.tsx
@@ -23,8 +23,12 @@ import { copyToClipboard, cn } from "@/lib/utils";
 interface JsonViewerProps {
   /** JSON Data */
   data: unknown;
+  /** Whether to use raw view by default */
+  defaultRawView?: boolean;
   /** Whether expanded by default */
   defaultExpanded?: boolean;
+  /** Whether to wrap lines by default */
+  defaultWrapLines?: boolean;
   /** Max height */
   maxHeight?: string;
   /** Custom class name */
@@ -45,7 +49,9 @@ interface JsonViewerProps {
  */
 export function JsonViewer({
   data,
+  defaultRawView = false,
   defaultExpanded = true,
+  defaultWrapLines = false,
   maxHeight = "400px",
   className,
   extraActions,
@@ -55,8 +61,8 @@ export function JsonViewer({
 }: JsonViewerProps) {
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(defaultExpanded);
-  const [internalWrapLines, setInternalWrapLines] = useState(false);
-  const [useRawView, setUseRawView] = useState(false);
+  const [internalWrapLines, setInternalWrapLines] = useState(defaultWrapLines);
+  const [useRawView, setUseRawView] = useState(defaultRawView);
   const [isDark, setIsDark] = useState(false);
   const wrapLines = controlledWrapLines ?? internalWrapLines;
 

--- a/frontend/src/components/common/StreamJsonViewer.tsx
+++ b/frontend/src/components/common/StreamJsonViewer.tsx
@@ -16,6 +16,10 @@ import { cn, copyToClipboard } from '@/lib/utils';
 interface StreamJsonViewerProps {
   /** Raw stream text */
   data: unknown;
+  /** Whether to use raw view by default */
+  defaultRawView?: boolean;
+  /** Whether to wrap lines by default */
+  defaultWrapLines?: boolean;
   /** Max height */
   maxHeight?: string;
   /** Custom class name */
@@ -217,11 +221,17 @@ const tokenClassName = (type: TokenType) => {
 /**
  * Stream JSON Viewer Component
  */
-export function StreamJsonViewer({ data, maxHeight = '400px', className }: StreamJsonViewerProps) {
+export function StreamJsonViewer({
+  data,
+  defaultRawView = false,
+  defaultWrapLines = false,
+  maxHeight = '400px',
+  className,
+}: StreamJsonViewerProps) {
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(true);
-  const [wrapLines, setWrapLines] = useState(false);
-  const [useRawView, setUseRawView] = useState(false);
+  const [wrapLines, setWrapLines] = useState(defaultWrapLines);
+  const [useRawView, setUseRawView] = useState(defaultRawView);
   const [isDark, setIsDark] = useState(false);
   const [expandedLines, setExpandedLines] = useState<Record<number, boolean>>({});
 

--- a/frontend/src/components/logs/LogDetail.tsx
+++ b/frontend/src/components/logs/LogDetail.tsx
@@ -513,9 +513,23 @@ export function LogDetail({ log }: LogDetailProps) {
 
   const renderPayloadViewer = (payload: unknown, maxHeight: string) => {
     if (isStreamPayload(payload)) {
-      return <StreamJsonViewer data={payload} maxHeight={maxHeight} />;
+      return (
+        <StreamJsonViewer
+          data={payload}
+          defaultRawView
+          defaultWrapLines
+          maxHeight={maxHeight}
+        />
+      );
     }
-    return <JsonViewer data={payload} maxHeight={maxHeight} />;
+    return (
+      <JsonViewer
+        data={payload}
+        defaultRawView
+        defaultWrapLines
+        maxHeight={maxHeight}
+      />
+    );
   };
 
   if (!log) return null;
@@ -992,6 +1006,8 @@ export function LogDetail({ log }: LogDetailProps) {
                 </div>
                 <JsonViewer
                   data={log.request_body}
+                  defaultRawView
+                  defaultWrapLines
                   maxHeight={layout === "horizontal" ? "65vh" : "45vh"}
                   extraActions={
                     <>
@@ -1052,6 +1068,8 @@ export function LogDetail({ log }: LogDetailProps) {
                   </div>
                   <JsonViewer
                     data={log.converted_request_body}
+                    defaultRawView
+                    defaultWrapLines
                     maxHeight={layout === "horizontal" ? "65vh" : "45vh"}
                     extraActions={
                       <Button
@@ -1139,13 +1157,21 @@ export function LogDetail({ log }: LogDetailProps) {
                 <h3 className="text-sm font-medium">
                   {t("detail.requestHeaders")}
                 </h3>
-                <JsonViewer data={log.request_headers || {}} />
+                <JsonViewer
+                  data={log.request_headers || {}}
+                  defaultRawView
+                  defaultWrapLines
+                />
               </div>
               <div className="space-y-3">
                 <h3 className="text-sm font-medium">
                   {t("detail.responseHeaders")}
                 </h3>
-                <JsonViewer data={log.response_headers || {}} />
+                <JsonViewer
+                  data={log.response_headers || {}}
+                  defaultRawView
+                  defaultWrapLines
+                />
               </div>
             </div>
           )}

--- a/frontend/src/components/logs/LogList.tsx
+++ b/frontend/src/components/logs/LogList.tsx
@@ -17,6 +17,12 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
   Eye, 
   ArrowRight,
   Waves,
@@ -60,101 +66,110 @@ export function LogList({ logs, onView }: LogListProps) {
   };
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="w-[180px]">{t('list.columns.time')}</TableHead>
-          <TableHead>{t('list.columns.provider')}</TableHead>
-          <TableHead>{t('list.columns.modelMapping')}</TableHead>
-          <TableHead>{t('list.columns.responseTime')}</TableHead>
-          <TableHead>{t('list.columns.tokenInOut')}</TableHead>
-          <TableHead>{t('list.columns.cost')}</TableHead>
-          <TableHead>{t('list.columns.statusRetry')}</TableHead>
-          <TableHead className="text-right">{t('list.columns.action')}</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {logs.map((log) => {
-          const statusColor = getStatusColor(log.response_status);
-          
-          return (
-            <TableRow key={log.id} className="group">
-              <TableCell className="font-mono text-xs text-muted-foreground">
-                <div>{formatDateTime(log.request_time)}</div>
-                <div className="mt-1 truncate opacity-0 transition-opacity group-hover:opacity-100" title={log.trace_id}>
-                  {log.trace_id?.slice(0, 8)}...
-                </div>
-              </TableCell>
-              <TableCell>{log.provider_name}</TableCell>
-              <TableCell>
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-center gap-1 font-medium">
-                    {log.requested_model}
-                    {log.requested_model !== log.target_model && (
-                      <>
-                        <ArrowRight className="h-3 w-3 text-muted-foreground" suppressHydrationWarning />
-                        <span className="text-muted-foreground">
-                          {log.target_model}
-                        </span>
-                      </>
-                    )}
-                    {log.is_stream && (
-                      <span title={t('list.streamRequest')} className="ml-1">
-                        <Waves className="h-3 w-3 text-blue-500" suppressHydrationWarning />
+    <TooltipProvider>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[180px]">{t('list.columns.time')}</TableHead>
+            <TableHead>{t('list.columns.provider')}</TableHead>
+            <TableHead>{t('list.columns.modelMapping')}</TableHead>
+            <TableHead>{t('list.columns.responseTime')}</TableHead>
+            <TableHead>{t('list.columns.tokenInOut')}</TableHead>
+            <TableHead>{t('list.columns.cost')}</TableHead>
+            <TableHead>{t('list.columns.statusRetry')}</TableHead>
+            <TableHead className="text-right">{t('list.columns.action')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {logs.map((log) => {
+            const statusColor = getStatusColor(log.response_status);
+            
+            return (
+              <TableRow key={log.id} className="group">
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  <div>{formatDateTime(log.request_time)}</div>
+                  <div className="mt-1 truncate opacity-0 transition-opacity group-hover:opacity-100" title={log.trace_id}>
+                    {log.trace_id?.slice(0, 8)}...
+                  </div>
+                </TableCell>
+                <TableCell>{log.provider_name}</TableCell>
+                <TableCell>
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-1 font-medium">
+                      {log.requested_model}
+                      {log.requested_model !== log.target_model && (
+                        <>
+                          <ArrowRight className="h-3 w-3 text-muted-foreground" suppressHydrationWarning />
+                          <span className="text-muted-foreground">
+                            {log.target_model}
+                          </span>
+                        </>
+                      )}
+                      {log.is_stream && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="ml-1 inline-flex cursor-help">
+                              <Waves className="h-3 w-3 text-blue-500" suppressHydrationWarning />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {t('list.streamRequest')}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {log.api_key_name}
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  {renderResponseTime(log)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col text-xs">
+                    <span>{t('list.inTokens', { count: log.input_tokens || 0 })}</span>
+                    <span className="text-muted-foreground">
+                      {t('list.outTokens', { count: log.output_tokens || 0 })}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell
+                  className="font-mono text-xs"
+                  title={t('list.costTooltip', {
+                    input: formatUsd(log.input_cost),
+                    output: formatUsd(log.output_cost),
+                  })}
+                >
+                  {formatUsd(log.total_cost)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col items-start gap-1">
+                    <Badge variant="outline" className={statusColor}>
+                      {log.response_status ?? t('unknown')}
+                    </Badge>
+                    {log.retry_count > 0 && (
+                      <span className="text-xs text-orange-500">
+                        {t('list.retry', { count: log.retry_count })}
                       </span>
                     )}
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    {log.api_key_name}
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                {renderResponseTime(log)}
-              </TableCell>
-              <TableCell>
-                <div className="flex flex-col text-xs">
-                  <span>{t('list.inTokens', { count: log.input_tokens || 0 })}</span>
-                  <span className="text-muted-foreground">
-                    {t('list.outTokens', { count: log.output_tokens || 0 })}
-                  </span>
-                </div>
-              </TableCell>
-              <TableCell
-                className="font-mono text-xs"
-                title={t('list.costTooltip', {
-                  input: formatUsd(log.input_cost),
-                  output: formatUsd(log.output_cost),
-                })}
-              >
-                {formatUsd(log.total_cost)}
-              </TableCell>
-              <TableCell>
-                <div className="flex flex-col items-start gap-1">
-                  <Badge variant="outline" className={statusColor}>
-                    {log.response_status ?? t('unknown')}
-                  </Badge>
-                  {log.retry_count > 0 && (
-                    <span className="text-xs text-orange-500">
-                      {t('list.retry', { count: log.retry_count })}
-                    </span>
-                  )}
-                </div>
-              </TableCell>
-              <TableCell className="text-right">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onView(log)}
-                  title={t('list.viewDetails')}
-                >
-                  <Eye className="h-4 w-4" suppressHydrationWarning />
-                </Button>
-              </TableCell>
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onView(log)}
+                    title={t('list.viewDetails')}
+                  >
+                    <Eye className="h-4 w-4" suppressHydrationWarning />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TooltipProvider>
   );
 }

--- a/frontend/src/components/playground/LogPlayground.tsx
+++ b/frontend/src/components/playground/LogPlayground.tsx
@@ -63,6 +63,8 @@ const FALLBACK_PROTOCOLS = [
   { protocol: 'gemini', label: 'Google Gemini', implementation: 'gemini' },
 ];
 
+const DEFAULT_EXPANDED_JSON_DEPTH = 4;
+
 function cloneJsonValue<T>(value: T): T {
   if (value === undefined) {
     return value;
@@ -183,7 +185,7 @@ function JsonNode({
   depth: number;
   onEdit: (path: JsonPath, label: string, value: unknown) => void;
 }) {
-  const [open, setOpen] = useState(depth < 1);
+  const [open, setOpen] = useState(depth <= DEFAULT_EXPANDED_JSON_DEPTH);
   const isContainer = Array.isArray(value) || (!!value && typeof value === 'object');
   const entries = Array.isArray(value)
     ? value.map((item, index) => ({ key: `[${index}]`, pathKey: index, value: item }))


### PR DESCRIPTION
This PR introduces a protocol conversion layer to enable interoperability between OpenAI and Anthropic API formats. It allows the proxy service to handle requests where the user's requested protocol differs from the supplier's supported protocol.

### Key Changes:

- **New Protocol Conversion Module**: Added `backend/app/common/protocol_conversion.py` which provides logic to transform requests, responses, and SSE streams between OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) formats.
- **Proxy Service Integration**: Updated `proxy_service.py` to detect protocol mismatches and automatically perform conversions before forwarding requests to suppliers and before returning responses to users.
- **Streaming Support**: Implemented complex SSE stream transformation logic to ensure that streaming responses remain compatible across different protocol types.
- **Dependencies**: Added `litellm` to `requirements.txt` and `pyproject.toml` to leverage its internal transformation utilities for robust protocol mapping.
- **Testing**: 
    - Added `test_protocol_conversion.py` for unit testing the conversion logic.
    - Updated `test_proxy_service_protocol_matching.py` to verify integration within the proxy flow.