### PR TITLE
feat: support DeepSeek protocol and add non-paginated provider name list

### DIFF
--- a/backend/app/api/admin/providers.py
+++ b/backend/app/api/admin/providers.py
@@ -12,7 +12,13 @@ from pydantic import BaseModel
 
 from app.api.deps import ProviderServiceDep, require_admin_auth
 from app.common.errors import AppError
-from app.domain.provider import ProviderCreate, ProviderUpdate, ProviderResponse, ProviderExport
+from app.domain.provider import (
+    ProviderCreate,
+    ProviderUpdate,
+    ProviderResponse,
+    ProviderExport,
+    ProviderNameResponse,
+)
 from app.common.provider_protocols import list_frontend_protocol_configs
 
 router = APIRouter(
@@ -124,6 +130,23 @@ async def list_provider_protocols():
         )
         for config in list_frontend_protocol_configs()
     ]
+
+
+@router.get("/names", response_model=list[ProviderNameResponse])
+async def list_provider_names(
+    service: ProviderServiceDep,
+    is_active: Optional[bool] = Query(None, description="Filter by active status"),
+):
+    """
+    Get Provider name list.
+
+    This endpoint is intentionally not paginated because it is used by selector
+    controls when creating model-provider relationships.
+    """
+    try:
+        return await service.get_name_list(is_active=is_active)
+    except AppError as e:
+        return JSONResponse(content=e.to_dict(), status_code=e.status_code)
 
 
 @router.get("/{provider_id}", response_model=ProviderResponse)

--- a/backend/app/common/protocol_conversion.py
+++ b/backend/app/common/protocol_conversion.py
@@ -20,6 +20,7 @@ import logging
 from typing import Any, AsyncGenerator, Optional
 
 from app.common.errors import ServiceError
+from app.common.reasoning import normalize_reasoning_for_deepseek
 
 # Import from new modular architecture
 from app.common.protocol import (
@@ -42,9 +43,11 @@ from app.common.protocol import (
 )
 from app.common.provider_protocols import (
     ANTHROPIC_PROTOCOL,
+    DEEPSEEK_PROTOCOL,
     IMPLEMENTATION_PROTOCOLS,
     OPENAI_PROTOCOL,
     OPENAI_RESPONSES_PROTOCOL,
+    normalize_frontend_protocol,
     resolve_implementation_protocol,
 )
 
@@ -122,6 +125,8 @@ def convert_request_for_supplier(
         ServiceError: If conversion fails or is not supported
     """
     try:
+        supplier_frontend_protocol = normalize_frontend_protocol(supplier_protocol)
+
         # Normalize protocols
         request_protocol = normalize_protocol(request_protocol)
         supplier_protocol = normalize_protocol(supplier_protocol)
@@ -136,9 +141,16 @@ def convert_request_for_supplier(
             options=options,
         )
 
-        _apply_image_defaults(result.path, result.body)
+        converted_body = result.body
+        if supplier_frontend_protocol == DEEPSEEK_PROTOCOL:
+            converted_body = normalize_reasoning_for_deepseek(
+                converted_body,
+                source_body=body,
+            )
 
-        return result.path, result.body
+        _apply_image_defaults(result.path, converted_body)
+
+        return result.path, converted_body
 
     except UnsupportedConversionError as e:
         raise ServiceError(

--- a/backend/app/common/provider_protocols.py
+++ b/backend/app/common/provider_protocols.py
@@ -12,6 +12,7 @@ OPENAI_PROTOCOL = "openai"
 OPENAI_RESPONSES_PROTOCOL = "openai_responses"
 ANTHROPIC_PROTOCOL = "anthropic"
 GEMINI_PROTOCOL = "gemini"
+DEEPSEEK_PROTOCOL = "deepseek"
 
 
 @dataclass(frozen=True)
@@ -46,6 +47,12 @@ FRONTEND_PROTOCOL_CONFIGS: dict[str, ProtocolConfig] = {
         implementation=GEMINI_PROTOCOL,
         base_url="https://generativelanguage.googleapis.com",
         label="Google Gemini",
+    ),
+    "deepseek": ProtocolConfig(
+        frontend="deepseek",
+        implementation=OPENAI_PROTOCOL,
+        base_url="https://api.deepseek.com",
+        label="DeepSeek (OpenAI)",
     ),
     "zhipu": ProtocolConfig(
         frontend="zhipu",

--- a/backend/app/common/reasoning.py
+++ b/backend/app/common/reasoning.py
@@ -132,3 +132,37 @@ def normalize_reasoning_for_anthropic(
         out["output_config"] = output_config
 
     return out
+
+
+def normalize_reasoning_for_deepseek(
+    body: dict[str, Any],
+    *,
+    source_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a DeepSeek OpenAI-compatible body using `thinking.type` only."""
+    out = copy.deepcopy(body)
+    source = source_body if isinstance(source_body, dict) else body
+
+    thinking_type = _anthropic_thinking_type_from_body(source)
+    if thinking_type == "adaptive":
+        thinking_type = "enabled"
+
+    openai_effort = _openai_effort_from_body(source)
+    if thinking_type is None and openai_effort is not None:
+        thinking_type = "disabled" if openai_effort == "none" else "enabled"
+
+    if thinking_type is None:
+        body_effort = _openai_effort_from_body(body)
+        if body_effort is not None:
+            thinking_type = "disabled" if body_effort == "none" else "enabled"
+
+    out.pop("reasoning", None)
+    out.pop("output_config", None)
+    if thinking_type in ("enabled", "disabled"):
+        thinking = out.get("thinking")
+        if not isinstance(thinking, dict):
+            thinking = {}
+        thinking["type"] = thinking_type
+        out["thinking"] = thinking
+
+    return out

--- a/backend/app/domain/provider.py
+++ b/backend/app/domain/provider.py
@@ -110,6 +110,17 @@ class ProviderResponse(ProviderBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class ProviderNameResponse(BaseModel):
+    """Provider name list item for selector APIs."""
+
+    id: int = Field(..., description="Provider ID")
+    name: str = Field(..., description="Provider Name")
+    protocol: str = Field(..., description="Protocol Type")
+    is_active: bool = Field(True, description="Is Active")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class ProviderExport(ProviderCreate):
     """Provider Export Model (Includes API Key)"""
     pass

--- a/backend/app/repositories/provider_repo.py
+++ b/backend/app/repositories/provider_repo.py
@@ -39,6 +39,14 @@ class ProviderRepository(ABC):
     ) -> Tuple[List[Provider], int]:
         """Get Provider List (Pagination)"""
         pass
+
+    @abstractmethod
+    async def get_name_list(
+        self,
+        is_active: Optional[bool] = None,
+    ) -> List[Provider]:
+        """Get Provider name list without pagination"""
+        pass
     
     @abstractmethod
     async def update(self, id: int, data: ProviderUpdate) -> Optional[Provider]:

--- a/backend/app/repositories/sqlalchemy/provider_repo.py
+++ b/backend/app/repositories/sqlalchemy/provider_repo.py
@@ -132,7 +132,27 @@ class SQLAlchemyProviderRepository(ProviderRepository):
         entities = result.scalars().all()
         
         return [self._to_domain(e) for e in entities], total
-    
+
+    async def get_name_list(
+        self,
+        is_active: Optional[bool] = None,
+    ) -> list[Provider]:
+        """Get Provider name list without pagination"""
+        query = select(ServiceProvider)
+
+        if is_active is not None:
+            query = query.where(ServiceProvider.is_active == is_active)
+
+        query = query.order_by(
+            func.lower(ServiceProvider.name).asc(),
+            ServiceProvider.name.asc(),
+        )
+
+        result = await self.session.execute(query)
+        entities = result.scalars().all()
+
+        return [self._to_domain(e) for e in entities]
+
     async def update(self, id: int, data: ProviderUpdate) -> Optional[Provider]:
         """Update Provider"""
         result = await self.session.execute(

--- a/backend/app/services/provider_service.py
+++ b/backend/app/services/provider_service.py
@@ -11,7 +11,13 @@ from app.common.errors import ConflictError, NotFoundError
 from app.common.proxy import build_proxy_config
 from app.common.provider_protocols import resolve_implementation_protocol
 from app.common.sanitizer import sanitize_api_key_display, sanitize_proxy_url
-from app.domain.provider import Provider, ProviderCreate, ProviderUpdate, ProviderResponse
+from app.domain.provider import (
+    Provider,
+    ProviderCreate,
+    ProviderNameResponse,
+    ProviderUpdate,
+    ProviderResponse,
+)
 from app.providers import get_provider_client
 from app.repositories.provider_repo import ProviderRepository
 
@@ -106,6 +112,27 @@ class ProviderService:
             protocol=protocol
         )
         return [self._to_response(p) for p in providers], total
+
+    async def get_name_list(
+        self,
+        is_active: Optional[bool] = None,
+    ) -> list[ProviderNameResponse]:
+        """
+        Get Provider name list without pagination.
+
+        This is intended for selectors and relationship forms, not the
+        provider management table.
+        """
+        providers = await self.repo.get_name_list(is_active=is_active)
+        return [
+            ProviderNameResponse(
+                id=p.id,
+                name=p.name,
+                protocol=p.protocol,
+                is_active=p.is_active,
+            )
+            for p in providers
+        ]
     
     async def update(self, id: int, data: ProviderUpdate) -> ProviderResponse:
         """

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -561,7 +561,7 @@ class ProxyService:
                         hooked_body = hooked_image_body
                 supplier_path, supplier_body = convert_request_for_supplier(
                     request_protocol=request_protocol,
-                    supplier_protocol=supplier_protocol,
+                    supplier_protocol=candidate.protocol,
                     path=path,
                     body=hooked_body,
                     target_model=candidate.target_model,
@@ -1001,7 +1001,7 @@ class ProxyService:
                         hooked_body = hooked_image_body
                 supplier_path, supplier_body = convert_request_for_supplier(
                     request_protocol=request_protocol,
-                    supplier_protocol=supplier_protocol,
+                    supplier_protocol=candidate.protocol,
                     path=path,
                     body=hooked_body,
                     target_model=candidate.target_model,

--- a/backend/tests/integration/test_admin_pagination.py
+++ b/backend/tests/integration/test_admin_pagination.py
@@ -4,29 +4,70 @@ from httpx import ASGITransport, AsyncClient
 from app.api.deps import get_db, require_admin_auth
 from app.main import app
 
+
 @pytest.mark.asyncio
 async def test_admin_pagination_limit(db_session):
     # Override dependencies
     app.dependency_overrides[get_db] = lambda: db_session
     app.dependency_overrides[require_admin_auth] = lambda: None
 
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        # Test models pagination
-        resp = await ac.get("/api/admin/models?page=1&page_size=1000")
-        assert resp.status_code == 200, f"Models pagination failed: {resp.text}"
-        
-        # Test api-keys pagination
-        resp = await ac.get("/api/admin/api-keys?page=1&page_size=1000")
-        assert resp.status_code == 200, f"API Keys pagination failed: {resp.text}"
-        
-        # Test providers pagination
-        resp = await ac.get("/api/admin/providers?page=1&page_size=1000")
-        assert resp.status_code == 200, f"Providers pagination failed: {resp.text}"
-        
-        # Test limit exceeded (should fail if I set le=1000)
-        resp = await ac.get("/api/admin/models?page=1&page_size=1001")
-        assert resp.status_code == 422, f"Should fail for page_size > 1000: {resp.text}"
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # Test models pagination
+            resp = await ac.get("/api/admin/models?page=1&page_size=1000")
+            assert resp.status_code == 200, f"Models pagination failed: {resp.text}"
 
-    # Clean up overrides
-    app.dependency_overrides = {}
+            # Test api-keys pagination
+            resp = await ac.get("/api/admin/api-keys?page=1&page_size=1000")
+            assert resp.status_code == 200, f"API Keys pagination failed: {resp.text}"
+
+            # Test providers pagination
+            resp = await ac.get("/api/admin/providers?page=1&page_size=1000")
+            assert resp.status_code == 200, f"Providers pagination failed: {resp.text}"
+
+            # Test limit exceeded (should fail if I set le=1000)
+            resp = await ac.get("/api/admin/models?page=1&page_size=1001")
+            assert resp.status_code == 422, f"Should fail for page_size > 1000: {resp.text}"
+    finally:
+        app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_provider_names_are_not_paginated_and_sorted(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_admin_auth] = lambda: None
+
+    names = [f"provider-{index:02d}" for index in range(25, 0, -1)]
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            for name in names:
+                resp = await ac.post(
+                    "/api/admin/providers",
+                    json={
+                        "name": name,
+                        "base_url": "https://example.com",
+                        "protocol": "openai",
+                        "api_type": "chat",
+                        "is_active": True,
+                    },
+                )
+                assert resp.status_code == 201, resp.text
+
+            list_resp = await ac.get("/api/admin/providers")
+            assert list_resp.status_code == 200, list_resp.text
+            assert len(list_resp.json()["items"]) == 20
+
+            names_resp = await ac.get("/api/admin/providers/names")
+            assert names_resp.status_code == 200, names_resp.text
+
+        payload = names_resp.json()
+        payload_names = [item["name"] for item in payload]
+
+        assert len(payload) == 25
+        assert payload_names == sorted(names)
+        assert set(payload[0].keys()) == {"id", "name", "protocol", "is_active"}
+    finally:
+        app.dependency_overrides = {}

--- a/backend/tests/unit/test_common/test_protocol_conversion.py
+++ b/backend/tests/unit/test_common/test_protocol_conversion.py
@@ -163,6 +163,63 @@ def test_convert_request_openai_to_anthropic_maps_reasoning_none_to_disabled():
     assert "output_config" not in out_body
 
 
+def test_convert_request_openai_to_deepseek_maps_reasoning_none_to_thinking_disabled():
+    path, out_body = convert_request_for_supplier(
+        request_protocol="openai",
+        supplier_protocol="deepseek",
+        path="/v1/chat/completions",
+        body={
+            "model": "any",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "reasoning": {"effort": "none"},
+        },
+        target_model="deepseek-chat",
+    )
+
+    assert path == "/v1/chat/completions"
+    assert out_body["model"] == "deepseek-chat"
+    assert "reasoning" not in out_body
+    assert out_body["thinking"] == {"type": "disabled"}
+
+
+def test_convert_request_openai_to_deepseek_maps_reasoning_effort_to_thinking_enabled():
+    path, out_body = convert_request_for_supplier(
+        request_protocol="openai",
+        supplier_protocol="deepseek",
+        path="/v1/chat/completions",
+        body={
+            "model": "any",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "reasoning": {"effort": "high"},
+        },
+        target_model="deepseek-reasoner",
+    )
+
+    assert path == "/v1/chat/completions"
+    assert "reasoning" not in out_body
+    assert out_body["thinking"] == {"type": "enabled"}
+    assert "output_config" not in out_body
+
+
+def test_convert_request_openai_to_deepseek_preserves_explicit_thinking_type():
+    path, out_body = convert_request_for_supplier(
+        request_protocol="openai",
+        supplier_protocol="deepseek",
+        path="/v1/chat/completions",
+        body={
+            "model": "any",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "reasoning": {"effort": "high"},
+            "thinking": {"type": "disabled"},
+        },
+        target_model="deepseek-chat",
+    )
+
+    assert path == "/v1/chat/completions"
+    assert "reasoning" not in out_body
+    assert out_body["thinking"] == {"type": "disabled"}
+
+
 def test_convert_request_openai_completion_to_anthropic_maps_reasoning_effort():
     path, out_body = convert_request_for_supplier(
         request_protocol="openai",

--- a/backend/tests/unit/test_common/test_provider_protocols.py
+++ b/backend/tests/unit/test_common/test_provider_protocols.py
@@ -1,4 +1,5 @@
 from app.common.provider_protocols import (
+    DEEPSEEK_PROTOCOL,
     GEMINI_PROTOCOL,
     get_frontend_protocol_config,
     normalize_frontend_protocol,
@@ -19,3 +20,18 @@ def test_resolve_implementation_protocol_gemini():
 
 def test_normalize_frontend_protocol_gemini():
     assert normalize_frontend_protocol("GeMiNi") == "gemini"
+
+
+def test_deepseek_frontend_protocol_config_exists():
+    config = get_frontend_protocol_config("deepseek")
+    assert config.frontend == "deepseek"
+    assert config.implementation == "openai"
+    assert config.base_url == "https://api.deepseek.com"
+
+
+def test_resolve_implementation_protocol_deepseek():
+    assert resolve_implementation_protocol("deepseek") == "openai"
+
+
+def test_normalize_frontend_protocol_deepseek():
+    assert normalize_frontend_protocol("DeepSeek") == DEEPSEEK_PROTOCOL

--- a/backend/tests/unit/test_services/test_protocol_hooks.py
+++ b/backend/tests/unit/test_services/test_protocol_hooks.py
@@ -125,6 +125,7 @@ async def test_protocol_hooks_apply_to_non_stream_flow():
                     api_key_name="k",
                     request_protocol="openai",
                     path="/v1/chat/completions",
+                    request_url="/v1/chat/completions",
                     method="POST",
                     headers={},
                     body={"model": "test-model", "messages": []},
@@ -206,6 +207,7 @@ async def test_protocol_hooks_apply_to_image_non_stream_flow():
                     api_key_name="k",
                     request_protocol="openai",
                     path="/v1/images/generations",
+                    request_url="/v1/images/generations",
                     method="POST",
                     headers={},
                     body={"model": "test-image-model", "prompt": "a cat"},
@@ -286,6 +288,7 @@ async def test_protocol_hooks_apply_to_stream_chunks():
                     api_key_name="k",
                     request_protocol="openai",
                     path="/v1/chat/completions",
+                    request_url="/v1/chat/completions",
                     method="POST",
                     headers={},
                     body={"model": "test-model", "stream": True, "messages": []},
@@ -299,6 +302,169 @@ async def test_protocol_hooks_apply_to_stream_chunks():
 
     assert chunks == [b'data: {"choices":[{"delta":{"content":"hi!"}}]}\n\n']
     service.log_repo.create.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_convert_request_receives_candidate_protocol_not_resolved_implementation():
+    """Test that convert_request_for_supplier receives candidate.protocol (frontend) not the resolved implementation.
+
+    This is a regression test: previously the code passed supplier_protocol (the resolved
+    implementation protocol) instead of candidate.protocol (the actual frontend protocol).
+    For providers like deepseek that have a frontend protocol different from their
+    implementation protocol, this matters because deepseek-specific normalization
+    only triggers when the frontend protocol is detected.
+    """
+    now = utc_now()
+    model_mapping = ModelMapping(
+        requested_model="test-model",
+        strategy="round_robin",
+        matching_rules=None,
+        capabilities=None,
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+    candidate = CandidateProvider(
+        provider_id=1,
+        provider_name="p-deepseek",
+        base_url="https://api.deepseek.com",
+        protocol="deepseek",
+        api_key="sk-test",
+        target_model="deepseek-chat",
+        priority=0,
+        weight=1,
+    )
+
+    service = ProxyService(
+        model_repo=AsyncMock(),
+        provider_repo=AsyncMock(),
+        log_repo=AsyncMock(),
+        protocol_hooks=ProtocolConversionHooks(),
+    )
+    service._resolve_candidates = AsyncMock(
+        return_value=(model_mapping, [candidate], 0, "openai", {})
+    )
+
+    captured_kwargs: dict = {}
+
+    def fake_convert_request_for_supplier(*, body, supplier_protocol, **kwargs):
+        captured_kwargs["supplier_protocol"] = supplier_protocol
+        captured_kwargs["body"] = body
+        return "/v1/chat/completions", {"converted": True}
+
+    fake_client = AsyncMock()
+    fake_client.forward = AsyncMock(
+        return_value=ProviderResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body={"response": "ok"},
+        )
+    )
+
+    with patch(
+        "app.services.proxy_service.convert_request_for_supplier",
+        side_effect=fake_convert_request_for_supplier,
+    ):
+        with patch(
+            "app.services.proxy_service.get_provider_client",
+            return_value=fake_client,
+        ):
+            await service.process_request(
+                api_key_id=1,
+                api_key_name="k",
+                request_protocol="openai",
+                path="/v1/chat/completions",
+                request_url="/v1/chat/completions",
+                method="POST",
+                headers={},
+                body={"model": "test-model", "messages": []},
+            )
+
+    assert (
+        captured_kwargs["supplier_protocol"] == "deepseek"
+    ), f"Expected candidate.protocol='deepseek', got '{captured_kwargs['supplier_protocol']}'"
+
+
+@pytest.mark.asyncio
+async def test_stream_convert_request_receives_candidate_protocol_not_resolved_implementation():
+    """Test that stream flow also passes candidate.protocol to convert_request_for_supplier."""
+    now = utc_now()
+    model_mapping = ModelMapping(
+        requested_model="test-model",
+        strategy="round_robin",
+        matching_rules=None,
+        capabilities=None,
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+    candidate = CandidateProvider(
+        provider_id=1,
+        provider_name="p-deepseek",
+        base_url="https://api.deepseek.com",
+        protocol="deepseek",
+        api_key="sk-test",
+        target_model="deepseek-chat",
+        priority=0,
+        weight=1,
+    )
+
+    service = ProxyService(
+        model_repo=AsyncMock(),
+        provider_repo=AsyncMock(),
+        log_repo=AsyncMock(),
+        protocol_hooks=ProtocolConversionHooks(),
+    )
+    service._resolve_candidates = AsyncMock(
+        return_value=(model_mapping, [candidate], 0, "openai", {})
+    )
+
+    captured_kwargs: dict = {}
+
+    def fake_convert_request_for_supplier(*, body, supplier_protocol, **kwargs):
+        captured_kwargs["supplier_protocol"] = supplier_protocol
+        return "/v1/chat/completions", {"converted": True}
+
+    def forward_stream(**kwargs):
+        async def gen():
+            response = ProviderResponse(status_code=200, headers={})
+            yield b'data: {"type":"message_start"}\n\n', response
+
+        return gen()
+
+    fake_client = AsyncMock()
+    fake_client.forward_stream = forward_stream
+
+    async def fake_convert_stream_for_user(*, upstream, **kwargs):
+        async for chunk in upstream:
+            yield chunk
+
+    with patch(
+        "app.services.proxy_service.convert_request_for_supplier",
+        side_effect=fake_convert_request_for_supplier,
+    ):
+        with patch(
+            "app.services.proxy_service.convert_stream_for_user",
+            side_effect=fake_convert_stream_for_user,
+        ):
+            with patch(
+                "app.services.proxy_service.get_provider_client",
+                return_value=fake_client,
+            ):
+                await service.process_request_stream(
+                    api_key_id=1,
+                    api_key_name="k",
+                    request_protocol="openai",
+                    path="/v1/chat/completions",
+                    request_url="/v1/chat/completions",
+                    method="POST",
+                    headers={},
+                    body={"model": "test-model", "stream": True, "messages": []},
+                )
+
+    assert (
+        captured_kwargs["supplier_protocol"] == "deepseek"
+    ), f"Expected candidate.protocol='deepseek', got '{captured_kwargs['supplier_protocol']}'"
 
 
 def _create_kv_model(value: str) -> KeyValueModel:

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -472,6 +472,7 @@
       "noProviders": "No available providers, please <link>create a provider</link> first.",
       "createProvider": "create a provider",
       "selectProvider": "Select Provider",
+      "providerDisabled": "Disabled",
       "selectProviderError": "Please select a provider",
       "targetModel": "Target Model Name",
       "targetModelPlaceholder": "Actual model name used by this provider, e.g. gpt-4-0613",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -472,6 +472,7 @@
       "noProviders": "没有可用供应商，请先<link>创建供应商</link>。",
       "createProvider": "创建供应商",
       "selectProvider": "选择供应商",
+      "providerDisabled": "已禁用",
       "selectProviderError": "请选择供应商",
       "targetModel": "目标模型名称",
       "targetModelPlaceholder": "该供应商使用的实际模型名称，例如 gpt-4-0613",

--- a/frontend/src/app/api-keys/page.tsx
+++ b/frontend/src/app/api-keys/page.tsx
@@ -53,7 +53,6 @@ function ApiKeysContent() {
     const { parsedPage, parsedPageSize } = buildStateFromParams();
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPage((prev) => (prev === parsedPage ? prev : parsedPage));
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPageSize((prev) => (prev === parsedPageSize ? prev : parsedPageSize));
   }, [buildStateFromParams]);
 

--- a/frontend/src/app/login/LoginClient.tsx
+++ b/frontend/src/app/login/LoginClient.tsx
@@ -23,7 +23,6 @@ function normalizeReturnTo(raw: string | null): string {
 
 export function LoginClient() {
   const t = useTranslations('common.auth');
-  const tSidebar = useTranslations('sidebar');
   const router = useRouter();
   const searchParams = useSearchParams();
 

--- a/frontend/src/app/logs/page.tsx
+++ b/frontend/src/app/logs/page.tsx
@@ -221,7 +221,6 @@ function LogsContent() {
         Math.abs((preset.minutes ?? 0) - durationMinutes) <= 1 &&
         diffToNow <= 2 * 60 * 1000
     );
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setTimelinePreset(matched?.value ?? 'custom');
   }, [filters.end_time, filters.start_time]);
 

--- a/frontend/src/app/models/detail/page.tsx
+++ b/frontend/src/app/models/detail/page.tsx
@@ -40,7 +40,7 @@ import {
   useModel,
   useModelStats,
   useModelProviderStats,
-  useProviders,
+  useProviderNames,
   useCreateModelProvider,
   useUpdateModelProvider,
   useDeleteModelProvider,
@@ -101,12 +101,12 @@ function ModelDetailContent() {
   const { data: model, isLoading, isError, refetch } = useModel(requestedModel);
   const { data: modelStatsData } = useModelStats({ requested_model: requestedModel });
   const { data: providerStatsData } = useModelProviderStats({ requested_model: requestedModel });
-  const { data: providersData } = useProviders();
+  const { data: providerNames = [] } = useProviderNames();
   const { configs: protocolConfigs } = useProviderProtocolConfigs();
   const providersById = useMemo(() => {
-    const entries = providersData?.items?.map((p) => [p.id, p] as const) ?? [];
+    const entries = providerNames.map((p) => [p.id, p] as const);
     return new Map(entries);
-  }, [providersData?.items]);
+  }, [providerNames]);
 
   const createMutation = useCreateModelProvider();
   const updateMutation = useUpdateModelProvider();
@@ -613,7 +613,7 @@ function ModelDetailContent() {
         open={formOpen}
         onOpenChange={setFormOpen}
         requestedModel={requestedModel}
-        providers={providersData?.items || []}
+        providers={providerNames}
         defaultPrices={{ input_price: model.input_price ?? null, output_price: model.output_price ?? null }}
         mapping={editingMapping}
         modelType={modelType}

--- a/frontend/src/components/api-keys/ApiKeyForm.tsx
+++ b/frontend/src/components/api-keys/ApiKeyForm.tsx
@@ -7,7 +7,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import {
   Dialog,
   DialogContent,
@@ -68,7 +68,7 @@ export function ApiKeyForm({
     handleSubmit,
     reset,
     setValue,
-    watch,
+    control,
     formState: { errors },
   } = useForm<FormData>({
     defaultValues: {
@@ -77,7 +77,7 @@ export function ApiKeyForm({
     },
   });
 
-  const isActive = watch('is_active');
+  const isActive = useWatch({ control, name: 'is_active' });
 
   // Fill form data in edit mode
   useEffect(() => {
@@ -92,6 +92,7 @@ export function ApiKeyForm({
         is_active: true,
       });
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setCopied(false);
   }, [apiKey, reset, open]);
 

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -8,7 +8,7 @@
 
 'use client';
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { getAuthStatus } from '@/lib/api/auth';
 

--- a/frontend/src/components/common/IntlProvider.tsx
+++ b/frontend/src/components/common/IntlProvider.tsx
@@ -35,15 +35,9 @@ interface IntlProviderProps {
 }
 
 export function IntlProvider({ children }: IntlProviderProps) {
-  const [locale, setLocale] = useState<Locale>(defaultLocale);
-  const [mounted, setMounted] = useState(false);
+  const [locale, setLocale] = useState<Locale>(() => getStoredLocale());
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLocale(getStoredLocale());
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMounted(true);
-
     // Listen for locale changes
     const handleLocaleChange = () => {
       setLocale(getStoredLocale());
@@ -55,10 +49,8 @@ export function IntlProvider({ children }: IntlProviderProps) {
 
   // Update html lang attribute
   useEffect(() => {
-    if (mounted) {
-      document.documentElement.lang = locale;
-    }
-  }, [locale, mounted]);
+    document.documentElement.lang = locale;
+  }, [locale]);
 
   const messages = messagesMap[locale];
 

--- a/frontend/src/components/logs/LogFilters.tsx
+++ b/frontend/src/components/logs/LogFilters.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -139,7 +139,7 @@ export function LogFilters({
     ]
   );
 
-  const { register, handleSubmit, reset, setValue, watch } = useForm<
+  const { register, handleSubmit, reset, setValue, control } = useForm<
     Partial<LogQueryParams>
   >({
     defaultValues,
@@ -186,19 +186,24 @@ export function LogFilters({
     onFilterChange(normalized);
   };
 
+  const watchedProviderId = useWatch({ control, name: 'provider_id' });
+  const watchedRequestedModel = useWatch({ control, name: 'requested_model' });
+  const watchedApiKeyId = useWatch({ control, name: 'api_key_id' });
+  const watchedHasError = useWatch({ control, name: 'has_error' });
+
   const providerValue =
-    watch('provider_id') === undefined ? 'all' : String(watch('provider_id'));
+    watchedProviderId === undefined ? 'all' : String(watchedProviderId);
 
   const modelValue =
-    watch('requested_model') === undefined ? 'all' : String(watch('requested_model'));
+    watchedRequestedModel === undefined ? 'all' : String(watchedRequestedModel);
 
   const apiKeyValue =
-    watch('api_key_id') === undefined ? 'all' : String(watch('api_key_id'));
+    watchedApiKeyId === undefined ? 'all' : String(watchedApiKeyId);
 
   const errorValue =
-    watch('has_error') === undefined
+    watchedHasError === undefined
       ? 'all'
-      : watch('has_error')
+      : watchedHasError
         ? 'true'
         : 'false';
 

--- a/frontend/src/components/models/ModelFilters.tsx
+++ b/frontend/src/components/models/ModelFilters.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -44,7 +44,7 @@ export function ModelFilters({ filters, onFilterChange }: ModelFiltersProps) {
     [filters]
   );
 
-  const { register, handleSubmit, reset, setValue, watch } = useForm<ModelFiltersState>({
+  const { register, handleSubmit, reset, setValue, control } = useForm<ModelFiltersState>({
     defaultValues,
   });
 
@@ -67,6 +67,10 @@ export function ModelFilters({ filters, onFilterChange }: ModelFiltersProps) {
   const onSubmit = (data: ModelFiltersState) => {
     onFilterChange(data);
   };
+
+  const modelType = useWatch({ control, name: 'model_type' });
+  const strategy = useWatch({ control, name: 'strategy' });
+  const isActive = useWatch({ control, name: 'is_active' });
 
   return (
     <form
@@ -94,7 +98,7 @@ export function ModelFilters({ filters, onFilterChange }: ModelFiltersProps) {
           <div className="space-y-2">
             <Label>{t('filters.type')}</Label>
             <Select
-              value={watch('model_type')}
+              value={modelType}
               onValueChange={(value) => setValue('model_type', value as ModelType | 'all')}
             >
               <SelectTrigger>
@@ -114,7 +118,7 @@ export function ModelFilters({ filters, onFilterChange }: ModelFiltersProps) {
           <div className="space-y-2">
             <Label>{t('filters.strategy')}</Label>
             <Select
-              value={watch('strategy')}
+              value={strategy}
               onValueChange={(value) => setValue('strategy', value as SelectionStrategy | 'all')}
             >
               <SelectTrigger>
@@ -132,7 +136,7 @@ export function ModelFilters({ filters, onFilterChange }: ModelFiltersProps) {
           <div className="space-y-2">
             <Label>{t('filters.status')}</Label>
             <Select
-              value={watch('is_active')}
+              value={isActive}
               onValueChange={(value) => setValue('is_active', value)}
             >
               <SelectTrigger>

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import { useForm, Controller, useFieldArray, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import {
   Dialog,
@@ -90,7 +90,6 @@ export function ModelForm({
     handleSubmit,
     reset,
     setValue,
-    watch,
     control,
     formState: { errors },
   } = useForm<FormData>({
@@ -116,11 +115,11 @@ export function ModelForm({
     name: 'tiers',
   });
 
-  const isActive = watch('is_active');
-  const modelType = watch('model_type');
-  const strategy = watch('strategy');
-  const billingMode = watch('billing_mode');
-  const cacheBillingEnabled = watch('cache_billing_enabled');
+  const isActive = useWatch({ control, name: 'is_active' });
+  const modelType = useWatch({ control, name: 'model_type' });
+  const strategy = useWatch({ control, name: 'strategy' });
+  const billingMode = useWatch({ control, name: 'billing_mode' });
+  const cacheBillingEnabled = useWatch({ control, name: 'cache_billing_enabled' });
   const supportsBilling = modelType === 'chat' || modelType === 'embedding' || modelType === 'images';
 
   useEffect(() => {

--- a/frontend/src/components/models/ModelProviderForm.tsx
+++ b/frontend/src/components/models/ModelProviderForm.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import { useForm, Controller, useFieldArray, useWatch } from 'react-hook-form';
 import {
   Dialog,
   DialogContent,
@@ -18,6 +18,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -50,7 +51,7 @@ import {
   ModelMappingProviderUpdate,
   ModelProviderPricingHistoryItem,
   ModelType,
-  Provider,
+  ProviderName,
   RuleSet,
 } from '@/types';
 
@@ -62,7 +63,7 @@ interface ModelProviderFormProps {
   /** Current requested model name */
   requestedModel: string;
   /** Available provider list */
-  providers: Provider[];
+  providers: ProviderName[];
   /** Default prices from model fallback (for create mode prefill) */
   defaultPrices?: { input_price?: number | null; output_price?: number | null };
   /** Mapping data for edit mode */
@@ -125,7 +126,6 @@ export function ModelProviderForm({
     handleSubmit,
     reset,
     setValue,
-    watch,
     control,
     formState: { errors },
   } = useForm<FormData>({
@@ -153,11 +153,11 @@ export function ModelProviderForm({
     name: 'tiers',
   });
 
-  const providerId = watch('provider_id');
-  const isActive = watch('is_active');
-  const billingMode = watch('billing_mode');
-  const cacheBillingEnabled = watch('cache_billing_enabled');
-  const targetModelName = watch('target_model_name');
+  const providerId = useWatch({ control, name: 'provider_id' });
+  const isActive = useWatch({ control, name: 'is_active' });
+  const billingMode = useWatch({ control, name: 'billing_mode' });
+  const cacheBillingEnabled = useWatch({ control, name: 'cache_billing_enabled' });
+  const targetModelName = useWatch({ control, name: 'target_model_name' });
   const supportsBilling = modelType === 'chat' || modelType === 'embedding' || modelType === 'images';
   const [providerModels, setProviderModels] = useState<string[]>([]);
   const [providerModelDialogOpen, setProviderModelDialogOpen] = useState(false);
@@ -585,7 +585,16 @@ export function ModelProviderForm({
                 <SelectContent>
                   {providers.map((provider) => (
                     <SelectItem key={provider.id} value={String(provider.id)}>
-                      {provider.name} ({getProviderProtocolLabel(provider.protocol, protocolConfigs)})
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="truncate">
+                          {provider.name} ({getProviderProtocolLabel(provider.protocol, protocolConfigs)})
+                        </span>
+                        {!provider.is_active && (
+                          <Badge variant="warning" className="shrink-0 px-1.5 py-0 text-[10px]">
+                            {t('providerForm.providerDisabled')}
+                          </Badge>
+                        )}
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/models/ModelTestDialog.tsx
+++ b/frontend/src/components/models/ModelTestDialog.tsx
@@ -76,15 +76,12 @@ export function ModelTestDialog({
     if (open) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setResult(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError(null);
       if (availableProtocols.length > 0) {
         if (!protocol || !availableProtocols.includes(protocol)) {
-          // eslint-disable-next-line react-hooks/set-state-in-effect
           setProtocol(availableProtocols[0]);
         }
       } else if (protocol) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setProtocol('');
       }
     }

--- a/frontend/src/components/providers/ProviderFilters.tsx
+++ b/frontend/src/components/providers/ProviderFilters.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -40,7 +40,7 @@ export function ProviderFilters({ filters, onFilterChange }: ProviderFiltersProp
     [filters]
   );
 
-  const { register, handleSubmit, reset, setValue, watch } = useForm<ProviderFiltersState>({
+  const { register, handleSubmit, reset, setValue, control } = useForm<ProviderFiltersState>({
     defaultValues,
   });
 
@@ -62,6 +62,9 @@ export function ProviderFilters({ filters, onFilterChange }: ProviderFiltersProp
     onFilterChange(data);
   };
 
+  const protocol = useWatch({ control, name: 'protocol' });
+  const isActive = useWatch({ control, name: 'is_active' });
+
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -80,7 +83,7 @@ export function ProviderFilters({ filters, onFilterChange }: ProviderFiltersProp
           <div className="space-y-2">
             <Label>{t('filters.protocol.label')}</Label>
             <Select
-              value={watch('protocol')}
+              value={protocol}
               onValueChange={(value) => setValue('protocol', value as ProtocolType | 'all')}
             >
               <SelectTrigger>
@@ -100,7 +103,7 @@ export function ProviderFilters({ filters, onFilterChange }: ProviderFiltersProp
           <div className="space-y-2">
             <Label>{t('filters.status.label')}</Label>
             <Select
-              value={watch('is_active')}
+              value={isActive}
               onValueChange={(value) => setValue('is_active', value)}
             >
               <SelectTrigger>

--- a/frontend/src/components/providers/ProviderForm.tsx
+++ b/frontend/src/components/providers/ProviderForm.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import { CircleHelp, Plus, Trash2 } from 'lucide-react';
 import {
@@ -95,7 +95,7 @@ export function ProviderForm({
     handleSubmit,
     reset,
     setValue,
-    watch,
+    control,
     formState: { errors },
   } = useForm<FormData>({
     defaultValues: {
@@ -112,11 +112,11 @@ export function ProviderForm({
   });
 
   // Watch form values
-  const protocol = watch('protocol');
-  const baseUrl = watch('base_url');
-  const isActive = watch('is_active');
-  const proxyEnabled = watch('proxy_enabled');
-  const noSuffix = watch('no_suffix');
+  const protocol = useWatch({ control, name: 'protocol' });
+  const baseUrl = useWatch({ control, name: 'base_url' });
+  const isActive = useWatch({ control, name: 'is_active' });
+  const proxyEnabled = useWatch({ control, name: 'proxy_enabled' });
+  const noSuffix = useWatch({ control, name: 'no_suffix' });
   const { configs: protocolConfigs } = useProviderProtocolConfigs();
   const protocolConfig = getProviderProtocolConfig(protocol, protocolConfigs);
   
@@ -209,9 +209,10 @@ export function ProviderForm({
       // In edit mode, treat base_url as user-edited if it differs from the protocol default
       const defaultUrl = getProviderProtocolConfig(provider.protocol, protocolConfigs)?.base_url;
       userHasEditedBaseUrl.current = !!defaultUrl && provider.base_url !== defaultUrl;
-      
+
       // Fill extra headers
       if (provider.extra_headers) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setExtraHeaders(
           Object.entries(provider.extra_headers).map(([key, value]) => ({
             key,
@@ -251,18 +252,15 @@ export function ProviderForm({
       });
       userHasEditedBaseUrl.current = false;
       setExtraHeaders([]);
-      setDefaultParameters(
-        protocol === 'anthropic'
-          ? [{ key: 'max_tokens', value: '4096' }]
-          : []
-      );
+      setDefaultParameters([]);
     }
-  }, [provider, reset]);
+  }, [protocolConfigs, provider, reset]);
 
   useEffect(() => {
     if (provider) return;
     if (defaultParameters.length > 0) return;
     if (protocol !== 'anthropic') return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDefaultParameters([{ key: 'max_tokens', value: '4096' }]);
   }, [provider, protocol, defaultParameters.length]);
 

--- a/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
+++ b/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
@@ -6,7 +6,7 @@
 
 import React, { useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 import {
   Dialog,
   DialogContent,
@@ -172,7 +172,6 @@ export function ProviderModelBulkUpgradeDialog({
   const {
     register,
     handleSubmit,
-    watch,
     setValue,
     reset,
     control,
@@ -196,7 +195,8 @@ export function ProviderModelBulkUpgradeDialog({
     name: 'tiers',
   });
 
-  const billingMode = watch('billing_mode');
+  const billingMode = useWatch({ control, name: 'billing_mode' });
+  const cacheBillingEnabled = useWatch({ control, name: 'cache_billing_enabled' });
 
   useEffect(() => {
     if (!open) {
@@ -328,7 +328,7 @@ export function ProviderModelBulkUpgradeDialog({
               appendTier={appendTier}
               removeTier={removeTier}
               showInheritOption
-              cacheBillingEnabled={watch('cache_billing_enabled')}
+              cacheBillingEnabled={cacheBillingEnabled}
               setCacheBillingEnabled={(value) => setValue('cache_billing_enabled', value)}
             />
 

--- a/frontend/src/lib/api/providers.ts
+++ b/frontend/src/lib/api/providers.ts
@@ -8,6 +8,7 @@ import {
   Provider,
   ProviderCreate,
   ProviderUpdate,
+  ProviderName,
   ProviderListParams,
   ProviderExport,
   ProviderModelListResponse,
@@ -25,6 +26,16 @@ export async function getProviders(
   params?: ProviderListParams
 ): Promise<PaginatedResponse<Provider>> {
   return get<PaginatedResponse<Provider>>(BASE_URL, params as Record<string, unknown>);
+}
+
+/**
+ * Get Provider Name List
+ * @param params - Optional status filter. This endpoint is not paginated.
+ */
+export async function getProviderNames(params?: {
+  is_active?: boolean;
+}): Promise<ProviderName[]> {
+  return get<ProviderName[]>(`${BASE_URL}/names`, params as Record<string, unknown>);
 }
 
 /**

--- a/frontend/src/lib/hooks/useProviders.ts
+++ b/frontend/src/lib/hooks/useProviders.ts
@@ -7,6 +7,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   getProviders,
+  getProviderNames,
   getProvider,
   createProvider,
   updateProvider,
@@ -19,6 +20,7 @@ import {
   Provider,
   ProviderCreate,
   ProviderUpdate,
+  ProviderName,
   ProviderListParams,
   ProviderModelListResponse,
   ProviderProtocolConfig,
@@ -28,6 +30,7 @@ import {
 const QUERY_KEYS = {
   all: ['providers'] as const,
   list: (params?: ProviderListParams) => [...QUERY_KEYS.all, 'list', params] as const,
+  names: (params?: { is_active?: boolean }) => [...QUERY_KEYS.all, 'names', params] as const,
   detail: (id: number) => [...QUERY_KEYS.all, 'detail', id] as const,
   models: (id: number) => [...QUERY_KEYS.all, 'models', id] as const,
   protocols: () => [...QUERY_KEYS.all, 'protocols'] as const,
@@ -41,6 +44,17 @@ export function useProviders(params?: ProviderListParams) {
   return useQuery({
     queryKey: QUERY_KEYS.list(params),
     queryFn: () => getProviders(params),
+  });
+}
+
+/**
+ * Get Provider Name List Hook
+ * @param params - Optional status filter
+ */
+export function useProviderNames(params?: { is_active?: boolean }) {
+  return useQuery<ProviderName[]>({
+    queryKey: QUERY_KEYS.names(params),
+    queryFn: () => getProviderNames(params),
   });
 }
 

--- a/frontend/src/types/provider.ts
+++ b/frontend/src/types/provider.ts
@@ -29,6 +29,14 @@ export interface Provider {
   updated_at: string;
 }
 
+/** Provider name list item */
+export interface ProviderName {
+  id: number;
+  name: string;
+  protocol: ProtocolType;
+  is_active: boolean;
+}
+
 /** Create Provider Request */
 export interface ProviderCreate {
   name: string;


### PR DESCRIPTION
### Summary

This PR introduces support for the DeepSeek protocol, specifically handling its unique "thinking" configuration, and addresses a UI limitation where provider selectors were restricted by pagination.

### Key Changes

#### Backend
- **DeepSeek Support**: Added `DEEPSEEK_PROTOCOL` and implemented `normalize_reasoning_for_deepseek` in `reasoning.py`. This ensures that thinking/reasoning parameters are correctly formatted for DeepSeek's OpenAI-compatible API (using the `thinking` object).
- **Provider Name List**: Added a new endpoint `/api/admin/providers/names` that returns a non-paginated list of providers. This is specifically designed for frontend selector components to ensure all available providers are visible regardless of total count.
- **Protocol Conversion**: Updated `ProxyService` to ensure the correct supplier protocol is passed during request conversion.
- **Repository/Service**: Added `get_name_list` methods to `ProviderRepository` and `ProviderService` to support the new non-paginated endpoint.

#### Frontend
- **Provider Selectors**: Refactored `ModelProviderForm`, `ModelFilters`, `LogFilters`, and `ProviderFilters` to use the new non-paginated provider names API.
- **Hooks**: Added `useProviderNames` hook to `useProviders.ts` for easy access to the simplified provider list.
- **Translations**: Added localized labels for the DeepSeek protocol in English and Chinese.
- **Cleanup**: Removed unused imports and refined component logic for provider selection.