### PR TITLE
fix: handle null tool_calls and allow clearing provider extra_headers

### DIFF
--- a/backend/app/services/protocol_hooks.py
+++ b/backend/app/services/protocol_hooks.py
@@ -174,8 +174,12 @@ class ProtocolConversionHooks:
                         except Exception as e:
                             logger.debug(f"Error caching reasoning_content: {e}")
 
-                    # Process tool_calls
-                    for tool_call in delta.get("tool_calls", []):
+                    # Process tool_calls. Some OpenAI-compatible providers return
+                    # explicit null when there are no tool calls.
+                    tool_calls = delta.get("tool_calls")
+                    if not isinstance(tool_calls, list):
+                        tool_calls = []
+                    for tool_call in tool_calls:
                         tool_call_id = tool_call.get("id", "")
                         
                         # Link tool_call_id to chat_id for reasoning_content recovery
@@ -219,7 +223,11 @@ class ProtocolConversionHooks:
             message = choice.get("message", {})
             reasoning_content = message.get("reasoning_content")
 
-            for tool_call in message.get("tool_calls", []):
+            tool_calls = message.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                tool_calls = []
+
+            for tool_call in tool_calls:
                 tool_call_id = tool_call.get("id", "")
                 if not tool_call_id:
                     continue
@@ -266,7 +274,9 @@ class ProtocolConversionHooks:
             if message.get("role") != "assistant":
                 continue
 
-            tool_calls = message.get("tool_calls", [])
+            tool_calls = message.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                tool_calls = []
             
             # Inject reasoning_content if missing
             if tool_calls and not message.get("reasoning_content"):

--- a/backend/tests/integration/test_admin_providers.py
+++ b/backend/tests/integration/test_admin_providers.py
@@ -1,0 +1,47 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_db, require_admin_auth
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_update_provider_can_clear_extra_headers(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_admin_auth] = lambda: None
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            create_resp = await ac.post(
+                "/api/admin/providers",
+                json={
+                    "name": "clear-extra-headers-provider",
+                    "base_url": "https://example.com",
+                    "protocol": "openai",
+                    "api_type": "chat",
+                    "is_active": True,
+                    "extra_headers": {"X-Test": "1"},
+                },
+            )
+            assert create_resp.status_code == 201, create_resp.text
+
+            provider = create_resp.json()
+            update_resp = await ac.put(
+                f"/api/admin/providers/{provider['id']}",
+                json={
+                    "name": provider["name"],
+                    "base_url": provider["base_url"],
+                    "protocol": provider["protocol"],
+                    "is_active": provider["is_active"],
+                    "extra_headers": {},
+                },
+            )
+            assert update_resp.status_code == 200, update_resp.text
+            assert update_resp.json()["extra_headers"] == {}
+
+            get_resp = await ac.get(f"/api/admin/providers/{provider['id']}")
+            assert get_resp.status_code == 200, get_resp.text
+            assert get_resp.json()["extra_headers"] == {}
+    finally:
+        app.dependency_overrides = {}

--- a/backend/tests/unit/test_services/test_protocol_hooks.py
+++ b/backend/tests/unit/test_services/test_protocol_hooks.py
@@ -855,6 +855,44 @@ async def test_cache_tool_call_extra_content_from_non_stream_response():
 
 
 @pytest.mark.asyncio
+async def test_cache_non_stream_response_handles_null_tool_calls():
+    """OpenAI-compatible providers may return tool_calls: null."""
+    mock_kv_repo = AsyncMock()
+    hooks = ProtocolConversionHooks(kv_repo=mock_kv_repo)
+
+    supplier_body = {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello",
+                    "reasoning_content": "Thinking",
+                    "tool_calls": None,
+                },
+            }
+        ],
+        "usage": {
+            "completion_tokens": 202,
+            "prompt_tokens": 252,
+            "total_tokens": 454,
+            "completion_tokens_details": {"reasoning_tokens": 151},
+            "prompt_tokens_details": {"cached_tokens": 192},
+        },
+    }
+
+    result = await hooks.before_response_conversion(
+        supplier_body=supplier_body,
+        request_protocol="openai",
+        supplier_protocol="openai",
+    )
+
+    mock_kv_repo.set.assert_not_called()
+    assert result == supplier_body
+
+
+@pytest.mark.asyncio
 async def test_cache_tool_call_extra_content_from_non_stream_response_multiple_tool_calls():
     """Test that extra_content is cached for multiple tool_calls with extra_content."""
     mock_kv_repo = AsyncMock()
@@ -951,6 +989,33 @@ async def test_cache_non_stream_response_skipped_for_non_dict_body():
 
     mock_kv_repo.set.assert_not_called()
     assert result == supplier_body
+
+
+@pytest.mark.asyncio
+async def test_inject_cached_content_handles_null_tool_calls():
+    """Requests with tool_calls: null should pass through cache injection."""
+    mock_kv_repo = AsyncMock()
+    hooks = ProtocolConversionHooks(kv_repo=mock_kv_repo)
+
+    body = {
+        "model": "mimo-v2.5-pro",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": "Hello",
+                "tool_calls": None,
+            }
+        ],
+    }
+
+    result = await hooks.before_request_conversion(
+        body=body,
+        request_protocol="openai",
+        supplier_protocol="openai",
+    )
+
+    mock_kv_repo.get.assert_not_called()
+    assert result == body
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/providers/ProviderForm.tsx
+++ b/frontend/src/components/providers/ProviderForm.tsx
@@ -308,6 +308,7 @@ export function ProviderForm({
       }
     });
 
+    const shouldIncludeHeaders = isEdit || Object.keys(headers).length > 0;
     const shouldIncludeOptions =
       data.no_suffix || !!provider?.provider_options?.no_suffix || Object.keys(params).length > 0;
 
@@ -318,7 +319,7 @@ export function ProviderForm({
       base_url: data.base_url,
       protocol: data.protocol,
       is_active: data.is_active,
-      extra_headers: Object.keys(headers).length > 0 ? headers : undefined,
+      extra_headers: shouldIncludeHeaders ? headers : undefined,
       provider_options: shouldIncludeOptions
         ? {
             default_parameters: Object.keys(params).length > 0 ? params : undefined,


### PR DESCRIPTION
This PR addresses two main issues related to provider integration and configuration:

### 1. Handle `null` tool_calls in Protocol Hooks
Some OpenAI-compatible providers (notably Xiaomi's API) return an explicit `null` for the `tool_calls` field in non-streaming responses, rather than an empty list or omitting the field. This was causing errors during protocol conversion. 
- Updated `backend/app/services/protocol_hooks.py` to safely handle cases where `tool_calls` is not a list.
- Added unit tests to verify that both request and response hooks correctly process `null` tool calls.

### 2. Allow Clearing Provider Extra Headers
Previously, the frontend would omit the `extra_headers` field if it was empty, making it impossible to clear existing headers when updating a provider.
- Modified `ProviderForm.tsx` to include the `extra_headers` object when editing, even if it is empty.
- Added an integration test to ensure that `extra_headers` can be successfully cleared via the API.

### Changes
- **Backend**: Improved robustness of `ProtocolConversionHooks` and added comprehensive tests.
- **Frontend**: Fixed logic in `ProviderForm` to support clearing extra headers during updates.