### PR TITLE
feat: implement protocol conversion between OpenAI and Anthropic

### DIFF
--- a/backend/app/common/token_counter.py
+++ b/backend/app/common/token_counter.py
@@ -18,6 +18,10 @@ except ImportError:
     TIKTOKEN_AVAILABLE = False
 
 
+def _encode_plain_text(encoding: Any, text: str) -> list[int]:
+    return encoding.encode(text, disallowed_special=())
+
+
 class TokenCounter(ABC):
     """
     Token Counter Abstract Base Class
@@ -244,7 +248,7 @@ class OpenAITokenCounter(TokenCounter):
 
         encoding = self._get_encoding(model)
         if encoding:
-            return len(encoding.encode(text))
+            return len(_encode_plain_text(encoding, text))
 
         # Fallback estimation: average 4 chars per token
         return len(text) // 4
@@ -351,7 +355,7 @@ class AnthropicTokenCounter(TokenCounter):
 
         encoding = self._get_encoding(model)
         if encoding:
-            return len(encoding.encode(text))
+            return len(_encode_plain_text(encoding, text))
 
         # Fallback estimation: average 4 chars per token
         return len(text) // 4

--- a/backend/tests/unit/test_common/test_token_counter.py
+++ b/backend/tests/unit/test_common/test_token_counter.py
@@ -36,6 +36,36 @@ def test_count_input_empty():
     assert counter.count_input([]) == 0
 
 
+def test_count_tokens_treats_reserved_special_token_text_as_plain_text():
+    text = "literal marker <|endoftext|> should not fail"
+
+    assert OpenAITokenCounter().count_tokens(text, "gpt-4") > 0
+    assert AnthropicTokenCounter().count_tokens(text, "claude-sonnet-4-0") > 0
+
+
+def test_anthropic_count_request_allows_reserved_special_token_text():
+    counter = AnthropicTokenCounter()
+    body = {
+        "model": "claude-sonnet-4-0",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_123",
+                        "content": [
+                            {"type": "text", "text": "literal <|endoftext|> value"}
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    assert counter.count_request(body) > 0
+
+
 def test_count_messages_with_image_detail_low_adds_tokens():
     counter = OpenAITokenCounter()
     image_payload = {


### PR DESCRIPTION
This PR introduces a protocol conversion layer to enable interoperability between OpenAI and Anthropic API formats within the proxy service. This allows users to send requests in one format (e.g., OpenAI) to a supplier that uses another (e.g., Anthropic).

### Key Changes:

- **New Protocol Conversion Module**: Added `backend/app/common/protocol_conversion.py` which handles the transformation of request bodies, response bodies, and SSE streams between OpenAI and Anthropic protocols using `litellm` utilities.
- **Proxy Service Integration**: Updated `proxy_service.py` to automatically detect protocol mismatches and apply the appropriate conversion logic before sending requests to suppliers and before returning responses to users.
- **Streaming Support**: Implemented `convert_stream_for_user` to handle real-time conversion of Server-Sent Events (SSE) between the two protocols.
- **Dependencies**: Added `litellm`, `openai`, and `pydantic` to `backend/requirements.txt` and `pyproject.toml`.
- **Testing**: Added comprehensive unit tests for the conversion logic and updated existing proxy service tests to reflect the new protocol matching behavior.