### PR TITLE
feat: add protocol conversion between OpenAI and Anthropic

### DIFF
--- a/backend/app/common/protocol/converters.py
+++ b/backend/app/common/protocol/converters.py
@@ -18,6 +18,7 @@ from app.common.reasoning import (
     normalize_reasoning_for_anthropic,
     normalize_reasoning_for_openai,
 )
+from app.common.usage_extractor import extract_usage_details
 
 from .base import (
     ConversionResult,
@@ -1962,6 +1963,11 @@ class SDKStreamConverter(IStreamConverter):
         current_block_type: Optional[str] = None
         # Track current tool call by id (more reliable than index which may be missing)
         current_tool_call_id: Optional[str] = None
+        # Usage + stop_reason are emitted in the trailing flush, because OpenAI
+        # streams deliver the real usage in a final chunk with empty `choices`
+        # (often AFTER the finish_reason chunk). Capture them as we go.
+        last_usage = None
+        pending_stop_reason: Optional[str] = None
 
         async for chunk in upstream:
             for payload in decoder.feed(chunk):
@@ -1993,6 +1999,13 @@ class SDKStreamConverter(IStreamConverter):
                     data = json.loads(payload)
                 except Exception:
                     continue
+
+                # Capture usage from every chunk BEFORE the empty-choices guard:
+                # the final usage chunk has `choices: []`, so reading it after the
+                # guard would drop it entirely.
+                chunk_usage = extract_usage_details(data)
+                if chunk_usage is not None:
+                    last_usage = chunk_usage
 
                 choices = data.get("choices", [])
                 if not choices:
@@ -2102,7 +2115,10 @@ class SDKStreamConverter(IStreamConverter):
 
                 # Handle Finish Reason
                 if finish_reason:
-                    # Close any open block
+                    # Close any open block now, but defer the terminal
+                    # message_delta/message_stop to the trailing flush so the
+                    # final usage chunk (which arrives after finish_reason with
+                    # empty choices) is included in the usage we emit.
                     if current_block_type is not None:
                         yield _encode_sse_json(
                             {
@@ -2111,24 +2127,57 @@ class SDKStreamConverter(IStreamConverter):
                             },
                             event="content_block_stop",
                         )
+                        current_block_type = None
 
-                    stop_reason = _map_openai_to_anthropic_finish_reason(finish_reason)
-                    yield _encode_sse_json(
-                        {
-                            "type": "message_delta",
-                            "delta": {"stop_reason": stop_reason},
-                            "usage": {"output_tokens": 0},
-                        },
-                        event="message_delta",
+                    pending_stop_reason = _map_openai_to_anthropic_finish_reason(
+                        finish_reason
                     )
 
-                    if not sent_message_stop:
-                        sent_message_stop = True
-                        yield _encode_sse_json(
-                            {"type": "message_stop"}, event="message_stop"
+        # Trailing flush: emit the terminal message_delta (carrying real usage)
+        # and message_stop once the upstream stream is fully drained.
+        if not sent_message_stop:
+            if current_block_type is not None:
+                yield _encode_sse_json(
+                    {
+                        "type": "content_block_stop",
+                        "index": current_block_index,
+                    },
+                    event="content_block_stop",
+                )
+                current_block_type = None
+
+            # Emit the terminal message_delta only when we have something real to
+            # report — a finish_reason or upstream usage — and a message was started.
+            # This avoids a spurious zero-usage message_delta for malformed/empty
+            # upstreams (matching the prior behavior) while still carrying usage when
+            # the supplier reports it without a finish_reason.
+            if sent_message_start and (
+                pending_stop_reason is not None or last_usage is not None
+            ):
+                usage_payload: Dict[str, Any] = {"output_tokens": 0}
+                if last_usage is not None:
+                    usage_payload = {
+                        "input_tokens": last_usage.input_tokens or 0,
+                        "output_tokens": last_usage.output_tokens or 0,
+                    }
+                    if last_usage.cached_tokens:
+                        usage_payload["cache_read_input_tokens"] = (
+                            last_usage.cached_tokens
+                        )
+                    if last_usage.cache_creation_input_tokens:
+                        usage_payload["cache_creation_input_tokens"] = (
+                            last_usage.cache_creation_input_tokens
                         )
 
-        if not sent_message_stop:
+                yield _encode_sse_json(
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": pending_stop_reason},
+                        "usage": usage_payload,
+                    },
+                    event="message_delta",
+                )
+
             sent_message_stop = True
             yield _encode_sse_json({"type": "message_stop"}, event="message_stop")
 

--- a/backend/tests/unit/test_common/test_protocol_conversion.py
+++ b/backend/tests/unit/test_common/test_protocol_conversion.py
@@ -12,7 +12,7 @@ from app.common.protocol_conversion import (
     convert_response_for_user,
     convert_stream_for_user,
 )
-from app.common.stream_usage import SSEDecoder
+from app.common.stream_usage import SSEDecoder, StreamUsageAccumulator
 
 
 @pytest.mark.asyncio
@@ -2088,3 +2088,124 @@ def test_sanitize_anthropic_tools_skips_malformed_entries():
     # must not raise
     out = sanitize_anthropic_tools(tools)
     assert len(out) == 3
+
+
+@pytest.mark.asyncio
+async def test_convert_stream_openai_to_anthropic_carries_usage_from_empty_choices_chunk():
+    """Regression: OpenAI streams report the real usage in a final chunk whose
+    `choices` is `[]` (often after the finish_reason chunk). That usage — including
+    cached tokens — must survive the OpenAI→Anthropic conversion and be readable by
+    the billing accumulator. See plan crispy-petting-mccarthy."""
+    content_chunk = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "claude-opus-4-8",
+        "choices": [{"index": 0, "delta": {"content": "Hi"}, "finish_reason": None}],
+        "usage": None,
+    }
+    finish_chunk = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "claude-opus-4-8",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        "usage": None,
+    }
+    # Real usage arrives last, with empty choices.
+    usage_chunk = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "claude-opus-4-8",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 373372,
+            "completion_tokens": 891,
+            "total_tokens": 374263,
+            "prompt_tokens_details": {"cached_tokens": 373245},
+        },
+    }
+    upstream = _agen(
+        [
+            f"data: {json.dumps(content_chunk)}\n\n".encode(),
+            f"data: {json.dumps(finish_chunk)}\n\n".encode(),
+            f"data: {json.dumps(usage_chunk)}\n\n".encode(),
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    # The accumulator consumes the CONVERTED (Anthropic) stream, exactly as
+    # proxy_service.process_request_stream does for a cross-protocol request.
+    acc = StreamUsageAccumulator(protocol="anthropic", model="claude-opus-4-8")
+    async for c in convert_stream_for_user(
+        request_protocol="anthropic",
+        supplier_protocol="openai",
+        upstream=upstream,
+        model="claude-opus-4-8",
+    ):
+        acc.feed(c)
+
+    result = acc.finalize()
+    assert result.input_tokens == 373372
+    assert result.output_tokens == 891
+    assert result.usage_details is not None
+    assert result.usage_details["cache_read_input_tokens"] == 373245
+
+
+@pytest.mark.asyncio
+async def test_convert_stream_openai_to_anthropic_empty_stream_no_spurious_message_delta():
+    """An empty/contentless upstream must emit only message_stop — never a
+    message_delta without a preceding message_start (which would be malformed
+    Anthropic SSE). Guards the trailing-flush logic."""
+    upstream = _agen([b"data: [DONE]\n\n"])
+
+    out = b""
+    async for c in convert_stream_for_user(
+        request_protocol="anthropic",
+        supplier_protocol="openai",
+        upstream=upstream,
+        model="claude-opus-4-8",
+    ):
+        out += c
+
+    decoder = SSEDecoder()
+    events = [
+        json.loads(p)["type"]
+        for p in decoder.feed(out)
+        if p.strip() != "[DONE]"
+    ]
+    assert events == ["message_stop"]
+
+
+@pytest.mark.asyncio
+async def test_convert_stream_openai_to_anthropic_usage_without_finish_reason():
+    """Some suppliers emit the usage chunk (empty choices) without ever sending a
+    finish_reason. Usage must still be carried into the terminal message_delta."""
+    content_chunk = {
+        "choices": [{"index": 0, "delta": {"content": "Hi"}, "finish_reason": None}],
+    }
+    usage_chunk = {
+        "choices": [],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 5},
+    }
+    upstream = _agen(
+        [
+            f"data: {json.dumps(content_chunk)}\n\n".encode(),
+            f"data: {json.dumps(usage_chunk)}\n\n".encode(),
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    acc = StreamUsageAccumulator(protocol="anthropic", model="claude-opus-4-8")
+    async for c in convert_stream_for_user(
+        request_protocol="anthropic",
+        supplier_protocol="openai",
+        upstream=upstream,
+        model="claude-opus-4-8",
+    ):
+        acc.feed(c)
+
+    result = acc.finalize()
+    assert result.input_tokens == 100
+    assert result.output_tokens == 5


### PR DESCRIPTION
## Summary

Implements bidirectional protocol conversion (OpenAI ↔ Anthropic) to support scenarios where the supplier protocol differs from the user request protocol.

## Changes

### New Features
- **`backend/app/common/protocol_conversion.py`** (404 lines): New module providing:
  - `convert_request_for_supplier()` – transforms user requests from one protocol to the supplier's expected protocol (path + body)
  - `convert_response_for_user()` – transforms non-streaming supplier responses back to the user's protocol
  - `convert_stream_for_user()` – async generator that converts SSE streaming responses between protocols
  - Supports `openai → anthropic` and `anthropic → openai` conversions for chat/messages endpoints
  - Uses `litellm` (`AnthropicConfig`, `AnthropicExperimentalPassThroughConfig`) for transformation logic

### Modified Files
- **`backend/app/services/proxy_service.py`**: Integrated protocol conversion into the proxy service to handle mismatched request/supplier protocols
- **`backend/pyproject.toml`** / **`backend/requirements.txt`**: Added `litellm` as a required dependency

### Tests
- **`tests/unit/test_common/test_protocol_conversion.py`** (194 lines): Unit tests covering request/response/stream conversion logic
- **`tests/unit/test_proxy_service_protocol_matching.py`**: Refactored existing tests (reduced by ~70 lines) to align with new conversion approach

## Dependencies

Adds `litellm` to backend dependencies for Anthropic/OpenAI protocol transformation.

## Notes

- Only `Chat Completions` (`/v1/chat/completions`) and `Messages` (`/v1/messages`) endpoints are supported for conversion
- Unsupported protocols or endpoints raise a `ServiceError` with appropriate error codes
- SSE streaming conversion handles `message_start`, `content_block_start/stop`, `message_delta`, and `message_stop` events