### PR TITLE
feat: add protocol conversion between OpenAI and Anthropic

### DIFF
--- a/backend/app/api/admin/logs.py
+++ b/backend/app/api/admin/logs.py
@@ -75,6 +75,15 @@ class RetryLogResponse(BaseModel):
     trace_id: str | None = None
 
 
+class ConvertedRequestResponse(BaseModel):
+    """Full (non-truncated) upstream request body, reconstructed on demand."""
+
+    converted_request_body: dict[str, Any] | None = None
+    upstream_url: str | None = None
+    request_method: str | None = None
+    supplier_protocol: str | None = None
+
+
 class PlaygroundExecuteRequest(BaseModel):
     """Editable playground request payload"""
 
@@ -562,6 +571,30 @@ async def get_log(
             if log.response_body
             else None,
         )
+    except AppError as e:
+        return JSONResponse(content=e.to_dict(), status_code=e.status_code)
+
+
+@router.get(
+    "/{log_id}/converted-request",
+    response_model=ConvertedRequestResponse,
+)
+async def get_converted_request(
+    log_id: int,
+    log_service: LogServiceDep,
+    proxy_service: ProxyServiceDep,
+):
+    """
+    Reconstruct the full (non-truncated) upstream request body.
+
+    The ``converted_request_body`` stored in logs is truncated for storage.
+    This re-runs the original protocol conversion logic against the full
+    request body so callers (e.g. "Copy as cURL") get the complete payload.
+    """
+    try:
+        log = await log_service.get_by_id(log_id)
+        result = await proxy_service.rebuild_converted_request(log)
+        return ConvertedRequestResponse(**result)
     except AppError as e:
         return JSONResponse(content=e.to_dict(), status_code=e.status_code)
 

--- a/backend/app/common/costs.py
+++ b/backend/app/common/costs.py
@@ -357,6 +357,7 @@ def calculate_cost_from_billing(
     cached_input_tokens: int | None = None,
     cached_output_tokens: int | None = None,
     cache_creation_input_tokens: int | None = None,
+    cache_tokens_separate: bool = False,
 ) -> CostBreakdown:
     if billing.billing_mode == BILLING_MODE_PER_REQUEST:
         total = _q4(_to_decimal(billing.per_request_price))
@@ -379,6 +380,7 @@ def calculate_cost_from_billing(
         cached_output_price=billing.cached_output_price,
         cache_creation_input_tokens=cache_creation_input_tokens,
         cache_creation_input_price=billing.cache_creation_input_price,
+        cache_tokens_separate=cache_tokens_separate,
     )
 
 
@@ -419,6 +421,7 @@ def calculate_cost(
     cached_output_price: float | None = None,
     cache_creation_input_tokens: int | None = None,
     cache_creation_input_price: float | None = None,
+    cache_tokens_separate: bool = False,
 ) -> CostBreakdown:
     in_tokens = int(input_tokens or 0)
     out_tokens = int(output_tokens or 0)
@@ -431,24 +434,36 @@ def calculate_cost(
         cached_input_tokens or cached_output_tokens or cache_creation_input_tokens
     ):
         # Split input tokens: read-cached + write-creation + non-cached.
-        # OpenAI semantics: cached_tokens ⊆ prompt_tokens. Anthropic semantics:
-        # cache_read_input_tokens and cache_creation_input_tokens are reported
-        # separately from input_tokens. We cap each individually at in_tokens
-        # (mirrors the existing cached_input_tokens cap), and additionally cap
-        # their combined sum at in_tokens so we never bill more cached/write
-        # tokens than the request actually used as input.
-        c_in = min(int(cached_input_tokens or 0), in_tokens)
-        c_create = min(int(cache_creation_input_tokens or 0), in_tokens)
-        # If both read and write are present, scale down proportionally so the
-        # combined cached/write tokens do not exceed in_tokens. This keeps the
-        # test_cached_exceeds_input behavior intact (single-side cap) and only
-        # kicks in when both sides are non-trivial.
-        total_cached = c_in + c_create
-        if total_cached > in_tokens:
-            scale = Decimal(in_tokens) / Decimal(total_cached)
-            c_in = int(Decimal(c_in) * scale)
-            c_create = int(Decimal(c_create) * scale)
-        non_cached_in = max(in_tokens - c_in - c_create, 0)
+        #
+        # Two upstream conventions exist:
+        #
+        # - OpenAI (cache_tokens_separate=False): cached_tokens ⊆ prompt_tokens.
+        #   The reported input_tokens already includes cached/write tokens, so
+        #   each is capped at in_tokens (and their combined sum capped too) and
+        #   subtracted out to derive the non-cached remainder.
+        #
+        # - Anthropic (cache_tokens_separate=True): cache_read_input_tokens and
+        #   cache_creation_input_tokens are reported separately from and in
+        #   addition to input_tokens. They must be billed in full alongside the
+        #   full input_tokens (no cap, no subtraction), otherwise the much
+        #   larger cache token counts collapse to ~0 against a tiny input_tokens.
+        if cache_tokens_separate:
+            c_in = int(cached_input_tokens or 0)
+            c_create = int(cache_creation_input_tokens or 0)
+            non_cached_in = max(in_tokens, 0)
+        else:
+            c_in = min(int(cached_input_tokens or 0), in_tokens)
+            c_create = min(int(cache_creation_input_tokens or 0), in_tokens)
+            # If both read and write are present, scale down proportionally so the
+            # combined cached/write tokens do not exceed in_tokens. This keeps the
+            # test_cached_exceeds_input behavior intact (single-side cap) and only
+            # kicks in when both sides are non-trivial.
+            total_cached = c_in + c_create
+            if total_cached > in_tokens:
+                scale = Decimal(in_tokens) / Decimal(total_cached)
+                c_in = int(Decimal(c_in) * scale)
+                c_create = int(Decimal(c_create) * scale)
+            non_cached_in = max(in_tokens - c_in - c_create, 0)
         # Effective cached input price: fall back to input_price if not set
         eff_cached_in_price = cached_input_price if cached_input_price is not None else input_price
         cached_in_cost = _q4(

--- a/backend/app/common/costs.py
+++ b/backend/app/common/costs.py
@@ -65,6 +65,9 @@ class ResolvedBilling:
     cache_billing_enabled: bool = False
     cached_input_price: float | None = None
     cached_output_price: float | None = None
+    # Cache write (creation) price, applied to cache_creation_input_tokens.
+    # Distinct from cached_input_price which is the cache read price.
+    cache_creation_input_price: float | None = None
 
 
 def resolve_price(
@@ -121,10 +124,10 @@ def _get_tier_value(t: object, key: str):
 
 def _select_tier(
     tiers: list[object] | None, *, input_tokens: int
-) -> tuple[float, float, float | None, float | None]:
-    """Select tier and return (input_price, output_price, cached_input_price, cached_output_price)."""
+) -> tuple[float, float, float | None, float | None, float | None]:
+    """Select tier and return (input, output, cached_input, cached_output, cache_creation_input) prices."""
     if not tiers:
-        return 0.0, 0.0, None, None
+        return 0.0, 0.0, None, None, None
 
     def tier_key(t: object) -> int:
         max_tokens = _get_tier_value(t, "max_input_tokens")
@@ -141,21 +144,25 @@ def _select_tier(
         if max_tokens is None or input_tokens <= int(max_tokens):
             cached_in = _get_tier_value(t, "cached_input_price")
             cached_out = _get_tier_value(t, "cached_output_price")
+            cache_create = _get_tier_value(t, "cache_creation_input_price")
             return (
                 float(_get_tier_value(t, "input_price") or 0.0),
                 float(_get_tier_value(t, "output_price") or 0.0),
                 float(cached_in) if cached_in is not None else None,
                 float(cached_out) if cached_out is not None else None,
+                float(cache_create) if cache_create is not None else None,
             )
 
     last = sorted_tiers[-1]
     cached_in = _get_tier_value(last, "cached_input_price")
     cached_out = _get_tier_value(last, "cached_output_price")
+    cache_create = _get_tier_value(last, "cache_creation_input_price")
     return (
         float(_get_tier_value(last, "input_price") or 0.0),
         float(_get_tier_value(last, "output_price") or 0.0),
         float(cached_in) if cached_in is not None else None,
         float(cached_out) if cached_out is not None else None,
+        float(cache_create) if cache_create is not None else None,
     )
 
 
@@ -164,21 +171,25 @@ def _resolve_cache_fields(
     provider_cache_billing_enabled: Optional[bool],
     provider_cached_input_price: Optional[float],
     provider_cached_output_price: Optional[float],
+    provider_cache_creation_input_price: Optional[float],
     model_cache_billing_enabled: Optional[bool],
     model_cached_input_price: Optional[float],
     model_cached_output_price: Optional[float],
+    model_cache_creation_input_price: Optional[float],
     is_provider_source: bool,
-) -> tuple[bool, float | None, float | None]:
+) -> tuple[bool, float | None, float | None, float | None]:
     """Resolve cache billing fields from provider > model fallback."""
     if is_provider_source:
         enabled = bool(provider_cache_billing_enabled)
         cached_in = provider_cached_input_price
         cached_out = provider_cached_output_price
+        cache_create = provider_cache_creation_input_price
     else:
         enabled = bool(model_cache_billing_enabled)
         cached_in = model_cached_input_price
         cached_out = model_cached_output_price
-    return enabled, cached_in, cached_out
+        cache_create = model_cache_creation_input_price
+    return enabled, cached_in, cached_out, cache_create
 
 
 def resolve_billing(
@@ -193,6 +204,7 @@ def resolve_billing(
     model_cache_billing_enabled: Optional[bool] = None,
     model_cached_input_price: Optional[float] = None,
     model_cached_output_price: Optional[float] = None,
+    model_cache_creation_input_price: Optional[float] = None,
     provider_billing_mode: Optional[str],
     provider_per_request_price: Optional[float],
     provider_per_image_price: Optional[float] = None,
@@ -202,6 +214,7 @@ def resolve_billing(
     provider_cache_billing_enabled: Optional[bool] = None,
     provider_cached_input_price: Optional[float] = None,
     provider_cached_output_price: Optional[float] = None,
+    provider_cache_creation_input_price: Optional[float] = None,
 ) -> ResolvedBilling:
     """
     Resolve effective billing config.
@@ -219,6 +232,7 @@ def resolve_billing(
         provider_cache_billing_enabled = None
         provider_cached_input_price = None
         provider_cached_output_price = None
+        provider_cache_creation_input_price = None
 
     # Determine effective billing source
     if provider_billing_mode and provider_billing_mode != BILLING_MODE_INHERIT_MODEL_DEFAULT:
@@ -262,24 +276,33 @@ def resolve_billing(
         )
 
     # Resolve cache billing for token-based modes
-    cache_enabled, cached_in_price, cached_out_price = _resolve_cache_fields(
+    cache_enabled, cached_in_price, cached_out_price, cache_create_price = _resolve_cache_fields(
         provider_cache_billing_enabled=provider_cache_billing_enabled,
         provider_cached_input_price=provider_cached_input_price,
         provider_cached_output_price=provider_cached_output_price,
+        provider_cache_creation_input_price=provider_cache_creation_input_price,
         model_cache_billing_enabled=model_cache_billing_enabled,
         model_cached_input_price=model_cached_input_price,
         model_cached_output_price=model_cached_output_price,
+        model_cache_creation_input_price=model_cache_creation_input_price,
         is_provider_source=is_provider_source if price_source is not None else False,
     )
 
     if mode == BILLING_MODE_TOKEN_TIERED:
         in_tokens = int(input_tokens or 0)
-        tier_in, tier_out, tier_cached_in, tier_cached_out = _select_tier(
-            eff_tiered_pricing, input_tokens=in_tokens
-        )
+        (
+            tier_in,
+            tier_out,
+            tier_cached_in,
+            tier_cached_out,
+            tier_cache_create,
+        ) = _select_tier(eff_tiered_pricing, input_tokens=in_tokens)
         # For tiered, per-tier cached prices override global cached prices
         eff_cached_in = tier_cached_in if tier_cached_in is not None else cached_in_price
         eff_cached_out = tier_cached_out if tier_cached_out is not None else cached_out_price
+        eff_cache_create = (
+            tier_cache_create if tier_cache_create is not None else cache_create_price
+        )
         return ResolvedBilling(
             billing_mode=mode,
             price_source=price_source,
@@ -288,6 +311,7 @@ def resolve_billing(
             cache_billing_enabled=cache_enabled,
             cached_input_price=eff_cached_in,
             cached_output_price=eff_cached_out,
+            cache_creation_input_price=eff_cache_create,
         )
 
     # Default: token_flat (legacy directional pricing supported)
@@ -305,10 +329,12 @@ def resolve_billing(
             cache_enabled = True
             cached_in_price = provider_cached_input_price
             cached_out_price = provider_cached_output_price
+            cache_create_price = provider_cache_creation_input_price
         elif model_cache_billing_enabled:
             cache_enabled = True
             cached_in_price = model_cached_input_price
             cached_out_price = model_cached_output_price
+            cache_create_price = model_cache_creation_input_price
 
     return ResolvedBilling(
         billing_mode=BILLING_MODE_TOKEN_FLAT,
@@ -318,6 +344,7 @@ def resolve_billing(
         cache_billing_enabled=cache_enabled,
         cached_input_price=cached_in_price,
         cached_output_price=cached_out_price,
+        cache_creation_input_price=cache_create_price,
     )
 
 
@@ -329,6 +356,7 @@ def calculate_cost_from_billing(
     image_count: int | None = None,
     cached_input_tokens: int | None = None,
     cached_output_tokens: int | None = None,
+    cache_creation_input_tokens: int | None = None,
 ) -> CostBreakdown:
     if billing.billing_mode == BILLING_MODE_PER_REQUEST:
         total = _q4(_to_decimal(billing.per_request_price))
@@ -349,6 +377,8 @@ def calculate_cost_from_billing(
         cached_output_tokens=cached_output_tokens,
         cached_input_price=billing.cached_input_price,
         cached_output_price=billing.cached_output_price,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_creation_input_price=billing.cache_creation_input_price,
     )
 
 
@@ -387,26 +417,60 @@ def calculate_cost(
     cached_output_tokens: int | None = None,
     cached_input_price: float | None = None,
     cached_output_price: float | None = None,
+    cache_creation_input_tokens: int | None = None,
+    cache_creation_input_price: float | None = None,
 ) -> CostBreakdown:
     in_tokens = int(input_tokens or 0)
     out_tokens = int(output_tokens or 0)
 
     cached_in_cost = Decimal("0")
     cached_out_cost = Decimal("0")
+    create_cost = Decimal("0")
 
-    if cache_billing_enabled and (cached_input_tokens or cached_output_tokens):
-        # Split input tokens
+    if cache_billing_enabled and (
+        cached_input_tokens or cached_output_tokens or cache_creation_input_tokens
+    ):
+        # Split input tokens: read-cached + write-creation + non-cached.
+        # OpenAI semantics: cached_tokens ⊆ prompt_tokens. Anthropic semantics:
+        # cache_read_input_tokens and cache_creation_input_tokens are reported
+        # separately from input_tokens. We cap each individually at in_tokens
+        # (mirrors the existing cached_input_tokens cap), and additionally cap
+        # their combined sum at in_tokens so we never bill more cached/write
+        # tokens than the request actually used as input.
         c_in = min(int(cached_input_tokens or 0), in_tokens)
-        non_cached_in = max(in_tokens - c_in, 0)
+        c_create = min(int(cache_creation_input_tokens or 0), in_tokens)
+        # If both read and write are present, scale down proportionally so the
+        # combined cached/write tokens do not exceed in_tokens. This keeps the
+        # test_cached_exceeds_input behavior intact (single-side cap) and only
+        # kicks in when both sides are non-trivial.
+        total_cached = c_in + c_create
+        if total_cached > in_tokens:
+            scale = Decimal(in_tokens) / Decimal(total_cached)
+            c_in = int(Decimal(c_in) * scale)
+            c_create = int(Decimal(c_create) * scale)
+        non_cached_in = max(in_tokens - c_in - c_create, 0)
         # Effective cached input price: fall back to input_price if not set
         eff_cached_in_price = cached_input_price if cached_input_price is not None else input_price
         cached_in_cost = _q4(
             (Decimal(c_in) / _ONE_MILLION) * _to_decimal(eff_cached_in_price)
         )
+
+        # Cache write (creation) tokens are billed separately at cache_creation_input_price,
+        # falling back to cached_input_price (cache read price) and finally to input_price.
+        if cache_creation_input_price is not None:
+            eff_create_price = cache_creation_input_price
+        elif cached_input_price is not None:
+            eff_create_price = cached_input_price
+        else:
+            eff_create_price = input_price
+        create_cost = _q4(
+            (Decimal(c_create) / _ONE_MILLION) * _to_decimal(eff_create_price)
+        )
+
         regular_in_cost = _q4(
             (Decimal(non_cached_in) / _ONE_MILLION) * _to_decimal(input_price)
         )
-        input_cost = _q4(regular_in_cost + cached_in_cost)
+        input_cost = _q4(regular_in_cost + cached_in_cost + create_cost)
 
         # Split output tokens
         c_out = min(int(cached_output_tokens or 0), out_tokens)
@@ -429,6 +493,6 @@ def calculate_cost(
         total_cost=float(total_cost),
         input_cost=float(input_cost),
         output_cost=float(output_cost),
-        cached_input_cost=float(cached_in_cost),
+        cached_input_cost=float(cached_in_cost + create_cost),
         cached_output_cost=float(cached_out_cost),
     )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -157,6 +157,10 @@ class ModelMapping(Base):
     cache_billing_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     cached_input_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
     cached_output_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
+    # Cache creation (cache WRITE) price, applied to cache_creation_input_tokens.
+    cache_creation_input_price: Mapped[Optional[float]] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
     # Is Active
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     # Creation Time
@@ -220,6 +224,10 @@ class ModelMappingProvider(Base):
     cache_billing_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     cached_input_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
     cached_output_price: Mapped[Optional[float]] = mapped_column(Numeric(12, 4), nullable=True)
+    # Cache creation (cache WRITE) price, applied to cache_creation_input_tokens.
+    cache_creation_input_price: Mapped[Optional[float]] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
     # Priority (Lower value means higher priority)
     priority: Mapped[int] = mapped_column(Integer, default=0)
     # Weight (Used for weighted round-robin, currently unused)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -146,6 +146,7 @@ def _run_migrations(sync_conn) -> None:
             "cache_billing_enabled": "cache_billing_enabled BOOLEAN DEFAULT FALSE",
             "cached_input_price": "cached_input_price NUMERIC(12,4)",
             "cached_output_price": "cached_output_price NUMERIC(12,4)",
+            "cache_creation_input_price": "cache_creation_input_price NUMERIC(12,4)",
         },
     )
     ensure_columns(
@@ -160,6 +161,7 @@ def _run_migrations(sync_conn) -> None:
             "cache_billing_enabled": "cache_billing_enabled BOOLEAN DEFAULT FALSE",
             "cached_input_price": "cached_input_price NUMERIC(12,4)",
             "cached_output_price": "cached_output_price NUMERIC(12,4)",
+            "cache_creation_input_price": "cache_creation_input_price NUMERIC(12,4)",
         },
     )
     ensure_columns(

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -26,8 +26,11 @@ class TokenTierPrice(BaseModel):
     )
     input_price: float = Field(..., ge=0, description="Input price ($/1M tokens)")
     output_price: float = Field(..., ge=0, description="Output price ($/1M tokens)")
-    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input price ($/1M tokens)")
+    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input (cache READ) price ($/1M tokens)")
     cached_output_price: Optional[float] = Field(None, ge=0, description="Cached output price ($/1M tokens)")
+    cache_creation_input_price: Optional[float] = Field(
+        None, ge=0, description="Cache creation (cache WRITE) price ($/1M tokens)"
+    )
 
 
 class ModelMappingBase(BaseModel):
@@ -65,8 +68,11 @@ class ModelMappingCreate(ModelMappingBase):
         None, description="Tiered pricing (based on input tokens)"
     )
     cache_billing_enabled: Optional[bool] = Field(None, description="Enable cache billing")
-    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input price ($/1M tokens)")
+    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input (cache READ) price ($/1M tokens)")
     cached_output_price: Optional[float] = Field(None, ge=0, description="Cached output price ($/1M tokens)")
+    cache_creation_input_price: Optional[float] = Field(
+        None, ge=0, description="Cache creation (cache WRITE) price ($/1M tokens)"
+    )
 
     @model_validator(mode="after")
     def _validate_billing(self) -> "ModelMappingCreate":
@@ -105,6 +111,7 @@ class ModelMappingUpdate(BaseModel):
     cache_billing_enabled: Optional[bool] = None
     cached_input_price: Optional[float] = Field(None, ge=0)
     cached_output_price: Optional[float] = Field(None, ge=0)
+    cache_creation_input_price: Optional[float] = Field(None, ge=0)
 
 
 class ModelMapping(ModelMappingBase):
@@ -121,6 +128,7 @@ class ModelMapping(ModelMappingBase):
     cache_billing_enabled: Optional[bool] = None
     cached_input_price: Optional[float] = None
     cached_output_price: Optional[float] = None
+    cache_creation_input_price: Optional[float] = None
     created_at: datetime
     updated_at: datetime
 
@@ -166,8 +174,11 @@ class ModelMatchProviderResponse(BaseModel):
         None, description="Tiered pricing (based on input tokens)"
     )
     cache_billing_enabled: Optional[bool] = Field(None, description="Cache billing enabled")
-    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input price ($/1M tokens)")
+    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input (cache READ) price ($/1M tokens)")
     cached_output_price: Optional[float] = Field(None, ge=0, description="Cached output price ($/1M tokens)")
+    cache_creation_input_price: Optional[float] = Field(
+        None, ge=0, description="Cache creation (cache WRITE) price ($/1M tokens)"
+    )
     model_input_price: Optional[float] = Field(
         None, description="Model fallback input price ($/1M tokens)"
     )
@@ -220,8 +231,11 @@ class ModelMappingProviderCreate(ModelMappingProviderBase):
     cache_billing_enabled: Optional[bool] = Field(
         None, description="Enable cache billing"
     )
-    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input price ($/1M tokens)")
+    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input (cache READ) price ($/1M tokens)")
     cached_output_price: Optional[float] = Field(None, ge=0, description="Cached output price ($/1M tokens)")
+    cache_creation_input_price: Optional[float] = Field(
+        None, ge=0, description="Cache creation (cache WRITE) price ($/1M tokens)"
+    )
 
     @model_validator(mode="after")
     def _validate_billing(self) -> "ModelMappingProviderCreate":
@@ -256,6 +270,7 @@ class ModelMappingProviderUpdate(BaseModel):
     cache_billing_enabled: Optional[bool] = None
     cached_input_price: Optional[float] = Field(None, ge=0)
     cached_output_price: Optional[float] = Field(None, ge=0)
+    cache_creation_input_price: Optional[float] = Field(None, ge=0)
 
 
 class ModelProviderBulkUpgradeRequest(BaseModel):
@@ -279,8 +294,11 @@ class ModelProviderBulkUpgradeRequest(BaseModel):
     cache_billing_enabled: Optional[bool] = Field(
         None, description="Enable cache billing"
     )
-    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input price ($/1M tokens)")
+    cached_input_price: Optional[float] = Field(None, ge=0, description="Cached input (cache READ) price ($/1M tokens)")
     cached_output_price: Optional[float] = Field(None, ge=0, description="Cached output price ($/1M tokens)")
+    cache_creation_input_price: Optional[float] = Field(
+        None, ge=0, description="Cache creation (cache WRITE) price ($/1M tokens)"
+    )
 
     @model_validator(mode="after")
     def _validate_billing(self) -> "ModelProviderBulkUpgradeRequest":
@@ -312,6 +330,7 @@ class ModelMappingProvider(ModelMappingProviderBase):
     cache_billing_enabled: Optional[bool] = None
     cached_input_price: Optional[float] = None
     cached_output_price: Optional[float] = None
+    cache_creation_input_price: Optional[float] = None
     priority: int = 0
     weight: int = 1
     is_active: bool = True
@@ -353,10 +372,13 @@ class ModelMappingProviderResponse(ModelMappingProvider):
         None, description="Resolved cache billing enabled"
     )
     resolved_cached_input_price: Optional[float] = Field(
-        None, ge=0, description="Resolved cached input price ($/1M tokens)"
+        None, ge=0, description="Resolved cached input (cache READ) price ($/1M tokens)"
     )
     resolved_cached_output_price: Optional[float] = Field(
         None, ge=0, description="Resolved cached output price ($/1M tokens)"
+    )
+    resolved_cache_creation_input_price: Optional[float] = Field(
+        None, ge=0, description="Resolved cache creation (cache WRITE) price ($/1M tokens)"
     )
     
     model_config = ConfigDict(from_attributes=True)
@@ -376,6 +398,7 @@ class ModelProviderExport(BaseModel):
     cache_billing_enabled: Optional[bool] = None
     cached_input_price: Optional[float] = None
     cached_output_price: Optional[float] = None
+    cache_creation_input_price: Optional[float] = None
     priority: int = 0
     weight: int = 1
     is_active: bool = True

--- a/backend/app/repositories/sqlalchemy/model_repo.py
+++ b/backend/app/repositories/sqlalchemy/model_repo.py
@@ -62,6 +62,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             cache_billing_enabled=entity.cache_billing_enabled,
             cached_input_price=float(entity.cached_input_price) if entity.cached_input_price is not None else None,
             cached_output_price=float(entity.cached_output_price) if entity.cached_output_price is not None else None,
+            cache_creation_input_price=float(entity.cache_creation_input_price) if entity.cache_creation_input_price is not None else None,
             created_at=ensure_utc(entity.created_at),
             updated_at=ensure_utc(entity.updated_at),
         )
@@ -96,6 +97,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             cache_billing_enabled=entity.cache_billing_enabled,
             cached_input_price=float(entity.cached_input_price) if entity.cached_input_price is not None else None,
             cached_output_price=float(entity.cached_output_price) if entity.cached_output_price is not None else None,
+            cache_creation_input_price=float(entity.cache_creation_input_price) if entity.cache_creation_input_price is not None else None,
             priority=entity.priority,
             weight=entity.weight,
             is_active=entity.is_active,
@@ -127,6 +129,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             cache_billing_enabled=data.cache_billing_enabled or False,
             cached_input_price=data.cached_input_price,
             cached_output_price=data.cached_output_price,
+            cache_creation_input_price=data.cache_creation_input_price,
         )
         self.session.add(entity)
         await self.session.commit()
@@ -278,6 +281,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             ),
             cached_input_price=data.cached_input_price,
             cached_output_price=data.cached_output_price,
+            cache_creation_input_price=data.cache_creation_input_price,
             priority=data.priority,
             weight=data.weight,
             is_active=data.is_active,

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -472,6 +472,9 @@ class ModelService:
             item.resolved_cached_output_price = (
                 model.cached_output_price if model else None
             )
+            item.resolved_cache_creation_input_price = (
+                model.cache_creation_input_price if model else None
+            )
             return item
 
         item.resolved_billing_mode = provider_mode
@@ -483,6 +486,7 @@ class ModelService:
         item.resolved_cache_billing_enabled = item.cache_billing_enabled
         item.resolved_cached_input_price = item.cached_input_price
         item.resolved_cached_output_price = item.cached_output_price
+        item.resolved_cache_creation_input_price = item.cache_creation_input_price
         return item
     
     async def update_provider_mapping(
@@ -529,6 +533,7 @@ class ModelService:
             "cache_billing_enabled": existing.cache_billing_enabled or False,
             "cached_input_price": existing.cached_input_price,
             "cached_output_price": existing.cached_output_price,
+            "cache_creation_input_price": existing.cache_creation_input_price,
         }
         merged.update(update_data)
         if merged.get("cache_billing_enabled") is None:
@@ -819,6 +824,7 @@ class ModelService:
             cache_billing_enabled=mapping.cache_billing_enabled,
             cached_input_price=mapping.cached_input_price,
             cached_output_price=mapping.cached_output_price,
+            cache_creation_input_price=mapping.cache_creation_input_price,
             created_at=mapping.created_at,
             updated_at=mapping.updated_at,
             provider_count=provider_count,

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -3,6 +3,7 @@
 Implements core business logic for request proxying."""
 
 import asyncio
+import copy
 import json
 import logging
 import time
@@ -28,7 +29,7 @@ from app.common.upstream_url import build_upstream_url
 from app.common.token_counter import get_token_counter
 from app.common.usage_extractor import extract_usage_details
 from app.common.utils import generate_trace_id
-from app.domain.log import RequestLogCreate
+from app.domain.log import RequestLogCreate, RequestLogModel
 from app.domain.model import ModelMapping, ModelMappingProviderResponse
 from app.domain.provider import Provider
 from app.providers import ProviderResponse, get_provider_client
@@ -248,6 +249,99 @@ class ProxyService:
         if not isinstance(provider_options, dict):
             return False
         return bool(provider_options.get("no_suffix"))
+
+    async def rebuild_converted_request(
+        self, log: RequestLogModel
+    ) -> dict[str, Any]:
+        """
+        Re-run the request protocol conversion for a stored log.
+
+        The ``converted_request_body`` persisted in logs is truncated for
+        storage (see ``_smart_truncate``), so this reconstructs the full,
+        non-truncated upstream request body on demand using the same
+        conversion pipeline (hooks + ``convert_request_for_supplier``) the
+        proxy used when the request was originally forwarded.
+
+        Returns a dict with ``converted_request_body``, ``upstream_url``,
+        ``request_method`` and ``supplier_protocol``.
+        """
+        if not log.detail_available or log.request_body is None:
+            raise ServiceError(
+                message="Request detail has expired for this log",
+                code="converted_request_detail_expired",
+            )
+        if isinstance(log.request_body, dict) and log.request_body.get("_files"):
+            raise ServiceError(
+                message="Multipart requests cannot be reconstructed",
+                code="converted_request_multipart_unsupported",
+            )
+        if not log.provider_id:
+            raise ServiceError(
+                message="Provider info is missing for this log",
+                code="converted_request_provider_missing",
+            )
+
+        provider = await self.provider_repo.get_by_id(log.provider_id)
+        if not provider:
+            raise NotFoundError(
+                message="Provider for this log no longer exists",
+                code="converted_request_provider_not_found",
+            )
+
+        request_protocol = (log.request_protocol or "openai").lower()
+        path = log.request_path or ""
+        target_model = log.target_model or log.requested_model or ""
+        # Work on a copy so conversion hooks cannot mutate the fetched log.
+        body = copy.deepcopy(log.request_body)
+        is_image_path = path in OPENAI_IMAGE_PATHS
+        supplier_protocol = resolve_implementation_protocol(provider.protocol)
+        conversion_options = self._build_conversion_options(provider.provider_options)
+
+        hooked_body = await self._protocol_hooks.before_request_conversion(
+            body, request_protocol, supplier_protocol
+        )
+        if hooked_body is None:
+            hooked_body = body
+        if is_image_path:
+            hooked_image_body = (
+                await self._protocol_hooks.before_image_request_conversion(
+                    hooked_body, request_protocol, supplier_protocol, path
+                )
+            )
+            if hooked_image_body is not None:
+                hooked_body = hooked_image_body
+
+        supplier_path, supplier_body = convert_request_for_supplier(
+            request_protocol=request_protocol,
+            supplier_protocol=provider.protocol,
+            path=path,
+            body=hooked_body,
+            target_model=target_model,
+            options=conversion_options,
+        )
+        if self._use_no_suffix(provider.provider_options):
+            supplier_path = ""
+
+        hooked_supplier_body = await self._protocol_hooks.after_request_conversion(
+            supplier_body, request_protocol, supplier_protocol
+        )
+        if hooked_supplier_body is not None:
+            supplier_body = hooked_supplier_body
+        if is_image_path:
+            hooked_image_supplier_body = (
+                await self._protocol_hooks.after_image_request_conversion(
+                    supplier_body, request_protocol, supplier_protocol, path
+                )
+            )
+            if hooked_image_supplier_body is not None:
+                supplier_body = hooked_image_supplier_body
+
+        return {
+            "converted_request_body": supplier_body,
+            "upstream_url": build_upstream_url(provider.base_url, supplier_path),
+            "request_method": (log.request_method or "POST").upper(),
+            "supplier_protocol": supplier_protocol,
+        }
 
     async def _resolve_candidates(
         self,
@@ -824,12 +918,21 @@ class ProxyService:
         # Extract cached tokens from usage details
         cached_input_tokens = None
         cache_creation_input_tokens = None
+        cache_tokens_separate = False
         if usage_details:
             cached_input_tokens = (
                 usage_details.get("cached_tokens")
                 or usage_details.get("cache_read_input_tokens")
             )
             cache_creation_input_tokens = usage_details.get("cache_creation_input_tokens")
+            # Anthropic reports cache_read/creation tokens separately from (and in
+            # addition to) input_tokens, unlike OpenAI where cached_tokens are a
+            # subset of prompt_tokens. Detect the Anthropic-style keys so billing
+            # does not cap the cache tokens against the much smaller input_tokens.
+            cache_tokens_separate = (
+                usage_details.get("cache_read_input_tokens") is not None
+                or usage_details.get("cache_creation_input_tokens") is not None
+            )
         cost = calculate_cost_from_billing(
             billing=billing,
             input_tokens=input_tokens,
@@ -837,6 +940,7 @@ class ProxyService:
             image_count=image_count,
             cached_input_tokens=cached_input_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_tokens_separate=cache_tokens_separate,
         )
         log_data = RequestLogCreate(
             request_time=request_time,
@@ -1449,12 +1553,19 @@ class ProxyService:
                 # Extract cached tokens from stream usage details
                 stream_cached_input_tokens = None
                 stream_cache_creation_input_tokens = None
+                stream_cache_tokens_separate = False
                 if usage_details:
                     stream_cached_input_tokens = (
                         usage_details.get("cached_tokens")
                         or usage_details.get("cache_read_input_tokens")
                     )
                     stream_cache_creation_input_tokens = usage_details.get("cache_creation_input_tokens")
+                    # See non-stream path: Anthropic reports cache tokens as
+                    # additive/separate from input_tokens.
+                    stream_cache_tokens_separate = (
+                        usage_details.get("cache_read_input_tokens") is not None
+                        or usage_details.get("cache_creation_input_tokens") is not None
+                    )
                 cost = calculate_cost_from_billing(
                     billing=billing,
                     input_tokens=input_tokens,
@@ -1462,6 +1573,7 @@ class ProxyService:
                     image_count=image_count,
                     cached_input_tokens=stream_cached_input_tokens,
                     cache_creation_input_tokens=stream_cache_creation_input_tokens,
+                    cache_tokens_separate=stream_cache_tokens_separate,
                 )
                 raw_stream_text = (
                     b"".join(raw_stream_chunks).decode("utf-8", errors="replace")

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -462,6 +462,7 @@ class ProxyService:
                 model_cache_billing_enabled=getattr(model_mapping, "cache_billing_enabled", None),
                 model_cached_input_price=getattr(model_mapping, "cached_input_price", None),
                 model_cached_output_price=getattr(model_mapping, "cached_output_price", None),
+                model_cache_creation_input_price=getattr(model_mapping, "cache_creation_input_price", None),
                 provider_billing_mode=provider_mapping.billing_mode
                 if provider_mapping
                 else None,
@@ -487,6 +488,9 @@ class ProxyService:
                 if provider_mapping
                 else None,
                 provider_cached_output_price=getattr(provider_mapping, "cached_output_price", None)
+                if provider_mapping
+                else None,
+                provider_cache_creation_input_price=getattr(provider_mapping, "cache_creation_input_price", None)
                 if provider_mapping
                 else None,
             )
@@ -813,20 +817,26 @@ class ProxyService:
             provider_cached_output_price=getattr(provider_mapping, "cached_output_price", None)
             if provider_mapping
             else None,
+            provider_cache_creation_input_price=getattr(provider_mapping, "cache_creation_input_price", None)
+            if provider_mapping
+            else None,
         )
         # Extract cached tokens from usage details
         cached_input_tokens = None
+        cache_creation_input_tokens = None
         if usage_details:
             cached_input_tokens = (
                 usage_details.get("cached_tokens")
                 or usage_details.get("cache_read_input_tokens")
             )
+            cache_creation_input_tokens = usage_details.get("cache_creation_input_tokens")
         cost = calculate_cost_from_billing(
             billing=billing,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             image_count=image_count,
             cached_input_tokens=cached_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
         )
         log_data = RequestLogCreate(
             request_time=request_time,
@@ -1223,6 +1233,7 @@ class ProxyService:
                 model_cache_billing_enabled=getattr(model_mapping, "cache_billing_enabled", None),
                 model_cached_input_price=getattr(model_mapping, "cached_input_price", None),
                 model_cached_output_price=getattr(model_mapping, "cached_output_price", None),
+                model_cache_creation_input_price=getattr(model_mapping, "cache_creation_input_price", None),
                 provider_billing_mode=provider_mapping.billing_mode
                 if provider_mapping
                 else None,
@@ -1248,6 +1259,9 @@ class ProxyService:
                 if provider_mapping
                 else None,
                 provider_cached_output_price=getattr(provider_mapping, "cached_output_price", None)
+                if provider_mapping
+                else None,
+                provider_cache_creation_input_price=getattr(provider_mapping, "cache_creation_input_price", None)
                 if provider_mapping
                 else None,
             )
@@ -1428,20 +1442,26 @@ class ProxyService:
                     provider_cached_output_price=getattr(provider_mapping, "cached_output_price", None)
                     if provider_mapping
                     else None,
+                    provider_cache_creation_input_price=getattr(provider_mapping, "cache_creation_input_price", None)
+                    if provider_mapping
+                    else None,
                 )
                 # Extract cached tokens from stream usage details
                 stream_cached_input_tokens = None
+                stream_cache_creation_input_tokens = None
                 if usage_details:
                     stream_cached_input_tokens = (
                         usage_details.get("cached_tokens")
                         or usage_details.get("cache_read_input_tokens")
                     )
+                    stream_cache_creation_input_tokens = usage_details.get("cache_creation_input_tokens")
                 cost = calculate_cost_from_billing(
                     billing=billing,
                     input_tokens=input_tokens,
                     output_tokens=usage_result.output_tokens,
                     image_count=image_count,
                     cached_input_tokens=stream_cached_input_tokens,
+                    cache_creation_input_tokens=stream_cache_creation_input_tokens,
                 )
                 raw_stream_text = (
                     b"".join(raw_stream_chunks).decode("utf-8", errors="replace")

--- a/backend/migrations/add_cache_creation_price_columns.sql
+++ b/backend/migrations/add_cache_creation_price_columns.sql
@@ -1,0 +1,5 @@
+-- Add cache_creation_input_price (cache WRITE price) columns to model_mappings
+-- and model_mapping_providers. Distinguishes the write-side cache price from
+-- the existing cached_input_price (cache READ price).
+ALTER TABLE model_mappings ADD COLUMN cache_creation_input_price NUMERIC(12, 4);
+ALTER TABLE model_mapping_providers ADD COLUMN cache_creation_input_price NUMERIC(12, 4);

--- a/backend/tests/unit/test_common/test_costs.py
+++ b/backend/tests/unit/test_common/test_costs.py
@@ -867,6 +867,59 @@ class TestCacheCreationBilling:
         assert cost.total_cost == 5.0
 
 
+# ==================== Anthropic separate (additive) cache tokens ====================
+
+
+class TestSeparateCacheTokens:
+    """cache_tokens_separate=True bills cache read/write in full alongside input.
+
+    Anthropic reports cache_read_input_tokens and cache_creation_input_tokens
+    separately from (and in addition to) input_tokens, so they must not be
+    capped against the small input_tokens value.
+    """
+
+    def test_anthropic_cache_billed_in_full(self):
+        # Real-world case: input=1, cache_creation=2186 @ $10, cache_read=87041
+        # @ $0.5, output=616 @ $25. The buggy OpenAI-cap path collapsed cache
+        # cost to ~0 and produced ~$0.0155.
+        cost = calculate_cost(
+            input_tokens=1,
+            output_tokens=616,
+            input_price=5.0,
+            output_price=25.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=87041,
+            cached_input_price=0.5,
+            cache_creation_input_tokens=2186,
+            cache_creation_input_price=10.0,
+            cache_tokens_separate=True,
+        )
+        # read:   87041/1M * 0.5  = 0.0435205 -> ceil 0.0436
+        # write:  2186/1M  * 10.0 = 0.02186   -> ceil 0.0219
+        # input:  1/1M     * 5.0  ~ 0          -> ceil 0.0001
+        # output: 616/1M   * 25.0 = 0.0154
+        assert cost.input_cost == 0.0656
+        assert cost.output_cost == 0.0154
+        assert cost.total_cost == 0.081
+        assert cost.cached_input_cost == 0.0655  # read 0.0436 + write 0.0219
+
+    def test_default_caps_like_openai(self):
+        """Without the flag, cache tokens are capped at input_tokens (legacy)."""
+        cost = calculate_cost(
+            input_tokens=1,
+            output_tokens=616,
+            input_price=5.0,
+            output_price=25.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=87041,
+            cached_input_price=0.5,
+            cache_creation_input_tokens=2186,
+            cache_creation_input_price=10.0,
+        )
+        # Cache tokens collapse against input_tokens=1; only output is billed.
+        assert cost.total_cost == 0.0155
+
+
 class TestResolveBillingCacheCreation:
     """resolve_billing correctly resolves cache_creation_input_price."""
 

--- a/backend/tests/unit/test_common/test_costs.py
+++ b/backend/tests/unit/test_common/test_costs.py
@@ -751,3 +751,236 @@ class TestCalculateCostFromBillingWithCache:
         # cached: 400k/1M * 1.5 = 0.6
         assert cost.input_cost == 2.4
         assert cost.cached_input_cost == 0.6
+
+
+# ==================== Cache Creation (Cache WRITE) Pricing Tests ====================
+
+
+class TestCacheCreationBilling:
+    """cache_creation_input_tokens billed at cache_creation_input_price."""
+
+    def test_write_tokens_billed_at_write_price(self):
+        """300k cache-write @ $6/1M + 200k regular @ $5/1M = $1.80 + $1.00 = $2.80"""
+        cost = calculate_cost(
+            input_tokens=500_000,
+            output_tokens=0,
+            input_price=5.0,
+            output_price=0.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=0,
+            cache_creation_input_tokens=300_000,
+            cache_creation_input_price=6.0,
+        )
+        # write: 300k/1M * 6 = 1.8
+        # regular: 200k/1M * 5 = 1.0
+        assert cost.input_cost == 2.8
+        assert cost.cached_input_cost == 1.8  # write cost folded into cached_input_cost
+        assert cost.total_cost == 2.8
+
+    def test_read_and_write_independent(self):
+        """read @ read price, write @ write price — both billed correctly."""
+        cost = calculate_cost(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            input_price=5.0,
+            output_price=0.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=400_000,
+            cached_input_price=1.0,
+            cache_creation_input_tokens=200_000,
+            cache_creation_input_price=6.0,
+        )
+        # read: 400k/1M * 1.0 = 0.4
+        # write: 200k/1M * 6.0 = 1.2
+        # regular: 400k/1M * 5.0 = 2.0
+        # total input_cost = 3.6
+        # cached_input_cost (read+write) = 1.6
+        assert cost.input_cost == 3.6
+        assert cost.cached_input_cost == 1.6
+        assert cost.total_cost == 3.6
+
+    def test_write_falls_back_to_read_price(self):
+        """When cache_creation_input_price is None, write tokens use cached_input_price."""
+        cost = calculate_cost(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            input_price=5.0,
+            output_price=0.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=0,
+            cache_creation_input_tokens=500_000,
+            cached_input_price=2.0,
+            # cache_creation_input_price omitted → falls back to cached_input_price
+        )
+        # write: 500k/1M * 2.0 = 1.0
+        # regular: 500k/1M * 5.0 = 2.5
+        assert cost.input_cost == 3.5
+        assert cost.cached_input_cost == 1.0
+
+    def test_write_falls_back_to_input_price(self):
+        """When neither write nor read price set, write uses input_price."""
+        cost = calculate_cost(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            input_price=5.0,
+            output_price=0.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=0,
+            cache_creation_input_tokens=400_000,
+            # both cached_input_price and cache_creation_input_price None
+        )
+        # write: 400k/1M * 5.0 = 2.0
+        # regular: 600k/1M * 5.0 = 3.0
+        assert cost.input_cost == 5.0
+        assert cost.cached_input_cost == 2.0
+
+    def test_write_capped_at_input_tokens(self):
+        """Write tokens capped at input_tokens."""
+        cost = calculate_cost(
+            input_tokens=100_000,
+            output_tokens=0,
+            input_price=5.0,
+            output_price=0.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=0,
+            cache_creation_input_tokens=200_000,  # > input_tokens
+            cache_creation_input_price=6.0,
+        )
+        # capped: 100k write, 0 regular
+        assert cost.cached_input_cost == 0.6  # 100k/1M * 6.0
+        assert cost.input_cost == 0.6
+
+    def test_write_disabled_when_cache_billing_disabled(self):
+        """cache_billing_enabled=False ignores write tokens entirely."""
+        cost = calculate_cost(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            input_price=5.0,
+            output_price=0.0,
+            cache_billing_enabled=False,
+            cache_creation_input_tokens=500_000,
+            cache_creation_input_price=6.0,
+        )
+        # All input billed at input_price: 1M/1M * 5 = 5.0
+        assert cost.input_cost == 5.0
+        assert cost.cached_input_cost == 0.0
+        assert cost.total_cost == 5.0
+
+
+class TestResolveBillingCacheCreation:
+    """resolve_billing correctly resolves cache_creation_input_price."""
+
+    def test_provider_cache_creation_wins(self):
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            provider_billing_mode="token_flat",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=5.0,
+            provider_output_price=15.0,
+            provider_cache_billing_enabled=True,
+            provider_cached_input_price=1.0,
+            provider_cache_creation_input_price=6.0,
+        )
+        assert billing.cache_creation_input_price == 6.0
+        assert billing.cached_input_price == 1.0
+
+    def test_model_fallback_for_cache_creation(self):
+        """No provider override → model cache_creation_input_price used."""
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode="token_flat",
+            model_cache_billing_enabled=True,
+            model_cached_input_price=1.0,
+            model_cache_creation_input_price=6.0,
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.cache_creation_input_price == 6.0
+        assert billing.cached_input_price == 1.0
+
+    def test_tiered_with_cache_creation(self):
+        """Tiered pricing resolves cache_creation_input_price from tier."""
+        billing = resolve_billing(
+            input_tokens=500_000,
+            model_input_price=None,
+            model_output_price=None,
+            model_billing_mode="token_tiered",
+            model_tiered_pricing=[
+                {
+                    "max_input_tokens": 1_000_000,
+                    "input_price": 3.0,
+                    "output_price": 4.0,
+                    "cached_input_price": 1.0,
+                    "cache_creation_input_price": 6.0,
+                }
+            ],
+            provider_billing_mode=None,
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+        )
+        assert billing.cached_input_price == 1.0
+        assert billing.cache_creation_input_price == 6.0
+
+    def test_inherit_model_default_clears_provider_cache_creation(self):
+        """inherit_model_default zeroes out provider cache_creation_input_price."""
+        billing = resolve_billing(
+            input_tokens=1000,
+            model_input_price=5.0,
+            model_output_price=15.0,
+            model_billing_mode="token_flat",
+            model_cache_billing_enabled=True,
+            model_cached_input_price=1.0,
+            model_cache_creation_input_price=6.0,
+            provider_billing_mode="inherit_model_default",
+            provider_per_request_price=None,
+            provider_tiered_pricing=None,
+            provider_input_price=None,
+            provider_output_price=None,
+            provider_cache_billing_enabled=True,
+            provider_cached_input_price=99.0,
+            provider_cache_creation_input_price=99.0,
+        )
+        # Provider override cleared; model values used
+        assert billing.cached_input_price == 1.0
+        assert billing.cache_creation_input_price == 6.0
+
+
+class TestCalculateCostFromBillingWithCacheCreation:
+    """calculate_cost_from_billing threads cache_creation_input_tokens/price."""
+
+    def test_calculate_cost_from_billing_write(self):
+        billing = ResolvedBilling(
+            billing_mode=BILLING_MODE_TOKEN_FLAT,
+            price_source="SupplierOverride",
+            input_price=5.0,
+            output_price=15.0,
+            cache_billing_enabled=True,
+            cached_input_price=1.0,
+            cache_creation_input_price=6.0,
+        )
+        cost = calculate_cost_from_billing(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            billing=billing,
+            cached_input_tokens=300_000,
+            cache_creation_input_tokens=200_000,
+        )
+        # read: 300k/1M * 1 = 0.3
+        # write: 200k/1M * 6 = 1.2
+        # regular: 500k/1M * 5 = 2.5
+        # total: 4.0
+        # cached_input_cost (read+write) = 1.5
+        assert cost.input_cost == 4.0
+        assert cost.cached_input_cost == 1.5
+        assert cost.total_cost == 4.0
+

--- a/docs/reviews/cache-pricing-review.md
+++ b/docs/reviews/cache-pricing-review.md
@@ -1,0 +1,174 @@
+# Code Review Prompt: 缓存计费修复 (Cache Pricing Fix)
+
+## 背景 (Context)
+
+Squirrel 是一个多供应商 LLM 网关，支持 Anthropic、OpenAI、Gemini。
+
+用户报告了一个 bug：**Cache Read 的 token 被按照 Cache Write 的价格计费了**。
+
+排查后发现这不是单点 bug，而是一组**概念错位 + 缺字段**的问题：
+
+1. **后端只有一个 `cached_input_price`**，但它在 `costs.py` 里实际被乘到了 `cache_read_input_tokens`（缓存读 token）上 —— 也就是说 `cached_input_price` 实际语义是"缓存读价"。
+2. **前端却把 `cached_input_price` 标签写成了"缓存写入价格 / Cache Write Price"**（`messages/en.json:528`、`messages/zh.json:528`），导致用户在"Cache Write Price"框里填的写价，被后端拿去给**缓存读** token 计费。
+3. **真正的缓存写 token（`cache_creation_input_tokens`）从来不计费** —— proxy 从不提取它用于计费。
+
+**目标**：引入一个语义清晰的 `cache_creation_input_price`（缓存写价）字段，让 `cached_input_price`（缓存读价）和 `cache_creation_input_price`（缓存写价）分别作用于对应的 token，前后端标签、计费、持久化、日志展示全链路语义一致。
+
+## 改动范围 (Files Changed)
+
+### 后端 (Backend)
+
+| 文件 | 改动 |
+|------|------|
+| `backend/app/common/costs.py` | `ResolvedBilling` 新增 `cache_creation_input_price`；`_select_tier` 返回 5 元组；`_resolve_cache_fields` 返回 4 元组；`resolve_billing` 在 `inherit_model_default` 清零块补一行、tiered 路径用 tier 写价覆盖、flat 路径补回退；`calculate_cost_from_billing` 新增 `cache_creation_input_tokens` 入参；`calculate_cost` 新增 `cache_creation_input_tokens`/`cache_creation_input_price` 入参，按 read + write + non-cached 三段拆分，并在 read+write 之和超过 `in_tokens` 时按比例收缩避免双重计算 |
+| `backend/app/domain/model.py` | 9 个 DTO 平行新增 `cache_creation_input_price` 字段（含 `TokenTierPrice`、`ModelMappingCreate/Update`、`ModelMapping`、`ModelMatchProviderResponse`、`ModelMappingProviderCreate/Update`、`ModelProviderBulkUpgradeRequest`、`ModelMappingProvider`、`ModelProviderExport`）和 `resolved_cache_creation_input_price` |
+| `backend/app/db/models.py` | `ModelMapping` 和 `ModelMappingProvider` ORM 各加一列 `cache_creation_input_price: Mapped[Optional[float]]` (Numeric(12, 4)) |
+| `backend/app/db/session.py` | `ensure_columns` 两个表都加 `"cache_creation_input_price": "cache_creation_input_price NUMERIC(12,4)"` |
+| `backend/migrations/add_cache_creation_price_columns.sql` | **新增迁移文件**，两表各 `ALTER TABLE ... ADD COLUMN cache_creation_input_price NUMERIC(12, 4)` |
+| `backend/app/repositories/sqlalchemy/model_repo.py` | to_domain 读列、create 写列；update_* 用 `model_dump(exclude_unset=True)` 自动兼容 |
+| `backend/app/services/model_service.py` | resolved_* 字段设置；`update_provider_mapping` 的 merged dict 补字段；响应构造补字段 |
+| `backend/app/services/proxy_service.py` | 4 处 `resolve_billing` 调用补 `model_cache_creation_input_price` 和 `provider_cache_creation_input_price`；2 处 `calculate_cost_from_billing` 调用补 `cache_creation_input_tokens` 并提取 `usage_details.get("cache_creation_input_tokens")` |
+
+### 前端 (Frontend)
+
+| 文件 | 改动 |
+|------|------|
+| `frontend/messages/en.json` | 修正 `cachedInputPrice` 文案为 "Cache Read Price"、新增 `cacheCreationInputPrice` / `tierCacheCreationInputPrice`；`cacheSuffix` 加写价占位符 |
+| `frontend/messages/zh.json` | 同步中文文案 |
+| `frontend/src/types/model.ts` | 11 处接口新增 `cache_creation_input_price`（响应类加 `resolved_cache_creation_input_price`） |
+| `frontend/src/lib/billing.ts` | `BillingSubmitData` / `BillingFormValues` / `buildBillingSubmitData()` 全分支 |
+| `frontend/src/lib/modelProviderPricingHistory.ts` | `ProviderBillingFormValues` 和 `getPriceHistoryFormValues()` 全分支 |
+| `frontend/src/lib/__tests__/modelProviderPricingHistory.test.ts` | fixture + 断言更新 |
+| `frontend/src/components/models/ModelProviderBillingFields.tsx` | `TierInputValue` / `BillingFormValues`；tiered 行新增 Input（grid 7→8 列）；flat 段新增 Input（grid 2→3 列）；`appendTier()` 默认值 |
+| `frontend/src/components/models/ModelForm.tsx` | FormData、defaults、mapping→form 转换、所有 submit 分支 |
+| `frontend/src/components/models/ModelProviderForm.tsx` | 同 ModelForm 模式 + `setValue` 在 `applyPriceHistory` 中 |
+| `frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx` | FormData、buildDefaultPricing（5 分支）、payload 序列化 |
+| `frontend/src/components/models/BillingDisplay.tsx` | `BillingTier` / props 加 `cacheCreationInputPrice`，cache suffix 同时显示读+写价 |
+| `frontend/src/app/models/detail/page.tsx` | 两处 `<BillingDisplay>` 调用传新 prop |
+
+## 关键设计决策 (Key Design Decisions)
+
+### 1. Token 拆分语义
+
+`calculate_cost` 中按 read + write + non-cached 三段拆分输入 token：
+
+```python
+c_in = min(int(cached_input_tokens or 0), in_tokens)
+c_create = min(int(cache_creation_input_tokens or 0), in_tokens)
+total_cached = c_in + c_create
+if total_cached > in_tokens:
+    # 按比例收缩，避免双重计算
+    scale = Decimal(in_tokens) / Decimal(total_cached)
+    c_in = int(Decimal(c_in) * scale)
+    c_create = int(Decimal(c_create) * scale)
+non_cached_in = max(in_tokens - c_in - c_create, 0)
+```
+
+**为什么需要收缩**：OpenAI 语义下 `cached_tokens ⊆ prompt_tokens`，Anthropic 语义下 `cache_read_input_tokens` 和 `cache_creation_input_tokens` 都是独立计数（理论上和 `input_tokens` 无关）。保守地按 `min(..., in_tokens)` 截断每个值，并当两者之和超过 `in_tokens` 时按比例缩放，保证总账单不超 input 量。
+
+### 2. 价格回退链
+
+`cache_creation_input_price` 为空时，回退顺序为：
+1. `cache_creation_input_price`（显式写价）
+2. `cached_input_price`（读价）
+3. `input_price`（基础价）
+
+### 3. CostBreakdown 字段
+
+`cached_input_cost` 字段保持不变（缓存输入合计），写价成本折进这个字段，**不新增字段**，避免 DB schema 改动。`CostBreakdown` 注释已说明。
+
+### 4. `cached_output_price` 不删除
+
+保留字段不删（避免破坏已存数据/导入导出），但本次不再依赖它。**Reviewer 重点确认**：是否同意保留这个 dead path，或者应该单独开一个清理任务。
+
+## 重点关注点 (Things to Review Carefully)
+
+### 1. 计费正确性 ⭐⭐⭐
+
+- `backend/app/common/costs.py:430-470` 的 read + write + non-cached 三段拆分逻辑
+- 特别注意：现有的 `cached_exceeds_input` 测试（`cached_input_tokens=200k`、`input_tokens=100k`）期望 `cached_input_cost=0.1`，我的修改不应该破坏这个行为
+- **务必跑一下**：
+  ```bash
+  cd backend && .venv/bin/python -m pytest tests/unit/test_common/test_costs.py -v
+  ```
+  应该有 44 个测试通过（34 旧 + 10 新）
+
+### 2. 前端标签语义 ⭐⭐⭐
+
+- **确认** `messages/en.json:528` 的 `cachedInputPrice` 现在是 "Cache Read Price"
+- **确认** `messages/zh.json:528` 的 `cachedInputPrice` 现在是 "缓存读取价格"
+- **确认** `cacheCreationInputPrice` 新增且文案正确
+- **确认** `cachedOutputPrice` 标签是否需要保留（语义上是"缓存输出价"，但 `cached_output_tokens` 从未填充过）
+
+### 3. 持久化往返 ⭐⭐
+
+- `backend/app/repositories/sqlalchemy/model_repo.py` 的 update_* 方法用 `model_dump(exclude_unset=True)`，自动兼容新字段 ✅
+- 确认 `_mapping_to_domain` 和 `_provider_mapping_to_domain` 都读取了新列
+- **务必验证**：`backend/migrations/add_cache_creation_price_columns.sql` 的语法是否与你使用的数据库兼容（目前是 PostgreSQL/SQLite 共用 ALTER TABLE ADD COLUMN）
+
+### 4. Proxy 集成 ⭐⭐
+
+- `backend/app/services/proxy_service.py` 的 4 处 `resolve_billing` 调用，确认都补了 `model_cache_creation_input_price` 和 `provider_cache_creation_input_price`（用 `getattr(..., None)` 模式以兼容旧数据）
+- 2 处 token 提取（line 821-832 非流式、line 1440-1452 流式）都从 `usage_details.get("cache_creation_input_tokens")` 读取
+- 构造一个带 cache 的请求，确认日志中 `cached_input_cost` 是 read + write 合计
+
+### 5. 前端表单 ⭐⭐
+
+- 检查 `ModelProviderBillingFields.tsx` 的 grid 列数：tiered 行从 7 改到 8、flat 段从 2 改到 3
+- 检查 `ModelForm.tsx` / `ModelProviderForm.tsx` / `ProviderModelBulkUpgradeDialog.tsx` 的所有 submit 分支
+- 浏览器实测：填写读价和写价 → 保存 → 重新打开 → 值是否回填
+
+### 6. 边界情况 ⭐
+
+- 旧模型（未设写价）的回归：`cache_creation_input_price=None` 时，write tokens 应回退到 read price 或 input price（已写测试覆盖）
+- `cache_billing_enabled=False` 时应忽略 write tokens（已写测试覆盖）
+- `inherit_model_default` 时 provider 的写价应被清零（已写测试覆盖）
+
+## 验证清单 (Verification Checklist)
+
+### 后端
+
+```bash
+cd backend
+.venv/bin/python -m pytest tests/unit/ -q          # 期望：596 passed
+.venv/bin/python -m pytest tests/unit/test_common/test_costs.py -v  # 期望：44 passed
+```
+
+### 前端
+
+```bash
+cd frontend
+npm test                                              # 期望：16 passed
+node_modules/.bin/tsc --noEmit                        # 期望：无输出
+node_modules/.bin/eslint src/types/model.ts src/lib/billing.ts \
+  src/lib/modelProviderPricingHistory.ts \
+  src/components/models/ModelProviderBillingFields.tsx \
+  src/components/models/ModelForm.tsx \
+  src/components/models/ModelProviderForm.tsx \
+  src/components/providers/ProviderModelBulkUpgradeDialog.tsx \
+  src/components/models/BillingDisplay.tsx \
+  src/app/models/detail/page.tsx \
+  src/lib/__tests__/modelProviderPricingHistory.test.ts
+                                                       # 期望：无输出
+```
+
+### 端到端
+
+1. 起 backend + frontend，构造一个带 cache 的 Anthropic 请求（usage 含 `cache_read_input_tokens` 和 `cache_creation_input_tokens`），走 proxy 后查 `request_logs.cached_input_cost`：
+   - 缓存读 token × 读价 + 缓存写 token × 写价 = 合计
+2. 起旧库跑一次，确认 `ensure_columns` 把两表的新列加上、二次启动不报错
+3. 在前端填读价和写价，保存，重新打开，确认回填；切语言，确认标签语义对齐
+
+## 不在本 PR 范围 (Out of Scope)
+
+- **不删除 `cached_output_price` / `cached_output_tokens` 字段**：保留以避免破坏已存数据/导入导出；后续单独清理
+- **不拆分 `CostBreakdown` 字段**：写价成本折进 `cached_input_cost`（不区分 read/write），避免 `RequestLog` schema 改动
+- **不在日志中显示 read/write 成本拆分**：`cached_input_cost` / `cached_output_cost` 列写入但从不读回，本次默认不做
+
+## 提问 (Questions for Reviewer)
+
+1. 是否同意保留 `cached_output_price` / `cached_output_tokens` 这条死链？还是要求本次就清理？
+2. `CostBreakdown` 是否需要拆出独立的 `cache_creation_input_cost` 字段？是否要求日志可读回？
+3. i18n 标签用 "Cache Read / 缓存读取"、"Cache Write / 缓存写入" 是否符合产品命名？
+4. 计费核心的 read + write + non-cached 三段拆分 + 比例收缩算法，是否同意这个保守实现？
+5. 数据库迁移文件 `add_cache_creation_price_columns.sql` 是否需要额外加索引/约束？

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -460,7 +460,7 @@
         "tieredPreview": "Tiered: {preview}{more}",
         "tieredPreviewMore": " (+{count})",
         "tieredEntry": "≤{max}: {input}/{output}",
-        "cacheSuffix": "Cached: {cachedInput}/{cachedOutput}",
+        "cacheSuffix": "Cache: read {cachedInput}/write {cacheCreationInput}/{cachedOutput}",
         "inheritModel": "Inherit model default"
       }
     },
@@ -525,11 +525,13 @@
       "noProviderModelsMatched": "No matching models found.",
       "useSelectedModel": "Use selected model",
       "cacheBilling": "Cache Billing",
-      "cachedInputPrice": "Cache Write Price (USD / 1M tokens)",
-      "cachedOutputPrice": "Cache Read Price (USD / 1M tokens)",
+      "cachedInputPrice": "Cache Read Price (USD / 1M tokens)",
+      "cachedOutputPrice": "Cache Output Price (USD / 1M tokens)",
+      "cacheCreationInputPrice": "Cache Write Price (USD / 1M tokens)",
       "cachedPricePlaceholder": "Empty = same as standard price",
-      "tierCachedInputPrice": "Cache Write (USD / 1M)",
-      "tierCachedOutputPrice": "Cache Read (USD / 1M)"
+      "tierCachedInputPrice": "Cache Read (USD / 1M)",
+      "tierCachedOutputPrice": "Cache Output (USD / 1M)",
+      "tierCacheCreationInputPrice": "Cache Write (USD / 1M)"
     },
     "ruleBuilder": {
       "title": "🎯 Matching Rules",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -460,7 +460,7 @@
         "tieredPreview": "分档：{preview}{more}",
         "tieredPreviewMore": " (+{count})",
         "tieredEntry": "≤{max}: {input}/{output}",
-        "cacheSuffix": "缓存：{cachedInput}/{cachedOutput}",
+        "cacheSuffix": "缓存：读 {cachedInput}/写 {cacheCreationInput}/{cachedOutput}",
         "inheritModel": "继承模型默认值"
       }
     },
@@ -525,11 +525,13 @@
       "noProviderModelsMatched": "没有匹配的模型。",
       "useSelectedModel": "使用所选模型",
       "cacheBilling": "缓存计费",
-      "cachedInputPrice": "缓存写入价格（美元/1M tokens）",
-      "cachedOutputPrice": "缓存读取价格（美元/1M tokens）",
+      "cachedInputPrice": "缓存读取价格（美元/1M tokens）",
+      "cachedOutputPrice": "缓存输出价格（美元/1M tokens）",
+      "cacheCreationInputPrice": "缓存写入价格（美元/1M tokens）",
       "cachedPricePlaceholder": "留空则同标准价格",
-      "tierCachedInputPrice": "缓存写入（美元/1M）",
-      "tierCachedOutputPrice": "缓存读取（美元/1M）"
+      "tierCachedInputPrice": "缓存读取（美元/1M）",
+      "tierCachedOutputPrice": "缓存输出（美元/1M）",
+      "tierCacheCreationInputPrice": "缓存写入（美元/1M）"
     },
     "ruleBuilder": {
       "title": "🎯 匹配规则",

--- a/frontend/src/app/models/detail/page.tsx
+++ b/frontend/src/app/models/detail/page.tsx
@@ -315,6 +315,7 @@ function ModelDetailContent() {
                     tieredPricing={model.tiered_pricing}
                     cacheBillingEnabled={model.cache_billing_enabled}
                     cachedInputPrice={model.cached_input_price}
+                    cacheCreationInputPrice={model.cache_creation_input_price}
                     cachedOutputPrice={model.cached_output_price}
                   />
                 </div>
@@ -462,6 +463,7 @@ function ModelDetailContent() {
                             fallbackOutputPrice={model.output_price}
                             cacheBillingEnabled={mapping.cache_billing_enabled}
                             cachedInputPrice={mapping.cached_input_price}
+                            cacheCreationInputPrice={mapping.cache_creation_input_price}
                             cachedOutputPrice={mapping.cached_output_price}
                           />
                         </TableCell>

--- a/frontend/src/components/logs/LogDetail.tsx
+++ b/frontend/src/components/logs/LogDetail.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/components/common/StreamJsonViewer";
 import { useTranslations } from "next-intl";
 import { getStoredAdminToken } from "@/lib/api/client";
+import { getConvertedRequest } from "@/lib/api/logs";
 
 interface LogDetailProps {
   /** Log data */
@@ -163,6 +164,15 @@ export function LogDetail({ log }: LogDetailProps) {
   const [traceCopied, setTraceCopied] = useState(false);
   const [originalCurlCopied, setOriginalCurlCopied] = useState(false);
   const [convertedCurlCopied, setConvertedCurlCopied] = useState(false);
+  // Full (non-truncated) converted upstream request body, reconstructed on
+  // demand from the server. Falls back to log.converted_request_body when not
+  // yet loaded or when reconstruction fails.
+  const [fullConvertedBody, setFullConvertedBody] = useState<Record<
+    string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  > | null>(null);
+  const [fullConvertedUrl, setFullConvertedUrl] = useState<string | null>(null);
   const [debugDialogOpen, setDebugDialogOpen] = useState(false);
   const [debugCopied, setDebugCopied] = useState(false);
   const [retryConfirmOpen, setRetryConfirmOpen] = useState(false);
@@ -183,6 +193,35 @@ export function LogDetail({ log }: LogDetailProps) {
     if (typeof window === "undefined") return;
     setClientOrigin(window.location.origin);
   }, []);
+
+  // Reconstruct the full converted upstream request body for the current log.
+  // The stored body is truncated for storage, so we fetch the complete one
+  // and use it for both the JSON display and "Copy as cURL".
+  const logId = log?.id;
+  const hasConvertedBody = Boolean(log?.converted_request_body);
+  useEffect(() => {
+    setFullConvertedBody(null);
+    setFullConvertedUrl(null);
+    if (!logId || !hasConvertedBody) return;
+    let cancelled = false;
+    getConvertedRequest(logId)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.converted_request_body) {
+          setFullConvertedBody(res.converted_request_body);
+        }
+        if (res.upstream_url) {
+          setFullConvertedUrl(res.upstream_url);
+        }
+      })
+      .catch(() => {
+        // Reconstruction failed (e.g. detail expired, provider removed).
+        // Fall back to the stored truncated body silently.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [logId, hasConvertedBody]);
 
   const responseStatus = log?.response_status;
   const statusVariant = useMemo<BadgeProps["variant"]>(() => {
@@ -272,10 +311,11 @@ export function LogDetail({ log }: LogDetailProps) {
   };
 
   const handleCopyConvertedAsCurl = async () => {
-    if (!log?.converted_request_body) return;
-    const method = (log.request_method || "POST").toUpperCase();
-    const url = log.upstream_url || "<URL>";
-    const body = JSON.stringify(log.converted_request_body, null, 2);
+    const convertedBody = fullConvertedBody ?? log?.converted_request_body;
+    if (!convertedBody) return;
+    const method = (log?.request_method || "POST").toUpperCase();
+    const url = fullConvertedUrl || log?.upstream_url || "<URL>";
+    const body = JSON.stringify(convertedBody, null, 2);
     const lines = [
       `curl -X ${method} '${url}'`,
       `  -H 'Content-Type: application/json'`,
@@ -1130,7 +1170,7 @@ export function LogDetail({ log }: LogDetailProps) {
                     )}
                   </div>
                   <JsonViewer
-                    data={log.converted_request_body}
+                    data={fullConvertedBody ?? log.converted_request_body}
                     defaultRawView
                     defaultWrapLines
                     maxHeight={layout === "horizontal" ? "65vh" : "45vh"}

--- a/frontend/src/components/models/BillingDisplay.tsx
+++ b/frontend/src/components/models/BillingDisplay.tsx
@@ -16,6 +16,7 @@ interface BillingTier {
   input_price: number;
   output_price: number;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
 }
 
@@ -30,6 +31,7 @@ interface BillingDisplayProps {
   fallbackOutputPrice?: number | null;
   cacheBillingEnabled?: boolean | null;
   cachedInputPrice?: number | null;
+  cacheCreationInputPrice?: number | null;
   cachedOutputPrice?: number | null;
   className?: string;
 }
@@ -70,6 +72,7 @@ export function BillingDisplay({
   fallbackOutputPrice,
   cacheBillingEnabled,
   cachedInputPrice,
+  cacheCreationInputPrice,
   cachedOutputPrice,
   className,
 }: BillingDisplayProps) {
@@ -119,11 +122,24 @@ export function BillingDisplay({
             tier.max_input_tokens === null || tier.max_input_tokens === undefined
               ? '∞'
               : String(tier.max_input_tokens);
-          return t('detail.billingDisplay.tieredEntry', {
+          let entry = t('detail.billingDisplay.tieredEntry', {
             max,
             input: formatUsdOrFree(tier.input_price),
             output: formatUsdOrFree(tier.output_price),
           });
+          if (
+            cacheBillingEnabled &&
+            (tier.cached_input_price != null ||
+              tier.cache_creation_input_price != null ||
+              tier.cached_output_price != null)
+          ) {
+            entry += ` ${t('detail.billingDisplay.cacheSuffix', {
+              cachedInput: formatUsdCeil4(tier.cached_input_price),
+              cacheCreationInput: formatUsdCeil4(tier.cache_creation_input_price),
+              cachedOutput: formatUsdCeil4(tier.cached_output_price),
+            })}`;
+          }
+          return entry;
         })
         .join(', ');
       const more =
@@ -143,9 +159,10 @@ export function BillingDisplay({
         output: formatUsdOrFree(effectiveOutput),
       });
     }
-    if (cacheBillingEnabled && (cachedInputPrice != null || cachedOutputPrice != null)) {
+    if (cacheBillingEnabled && (cachedInputPrice != null || cacheCreationInputPrice != null || cachedOutputPrice != null)) {
       text += ` ${t('detail.billingDisplay.cacheSuffix', {
         cachedInput: formatUsdCeil4(cachedInputPrice),
+        cacheCreationInput: formatUsdCeil4(cacheCreationInputPrice),
         cachedOutput: formatUsdCeil4(cachedOutputPrice),
       })}`;
     }

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -62,9 +62,10 @@ interface FormData {
   output_price: string;
   per_request_price: string;
   per_image_price: string;
-  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cached_output_price: string }>;
+  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cache_creation_input_price: string; cached_output_price: string }>;
   cache_billing_enabled: boolean;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
 }
 
@@ -103,9 +104,10 @@ export function ModelForm({
       output_price: '',
       per_request_price: '',
       per_image_price: '',
-      tiers: [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     },
   });
@@ -156,6 +158,7 @@ export function ModelForm({
             : String(model.per_image_price),
         cache_billing_enabled: !!model.cache_billing_enabled,
         cached_input_price: model.cached_input_price === null || model.cached_input_price === undefined ? '' : String(model.cached_input_price),
+        cache_creation_input_price: model.cache_creation_input_price === null || model.cache_creation_input_price === undefined ? '' : String(model.cache_creation_input_price),
         cached_output_price: model.cached_output_price === null || model.cached_output_price === undefined ? '' : String(model.cached_output_price),
         tiers:
           model.tiered_pricing && model.tiered_pricing.length > 0
@@ -167,9 +170,10 @@ export function ModelForm({
                 input_price: String(t.input_price),
                 output_price: String(t.output_price),
                 cached_input_price: t.cached_input_price === null || t.cached_input_price === undefined ? '' : String(t.cached_input_price),
+                cache_creation_input_price: t.cache_creation_input_price === null || t.cache_creation_input_price === undefined ? '' : String(t.cache_creation_input_price),
                 cached_output_price: t.cached_output_price === null || t.cached_output_price === undefined ? '' : String(t.cached_output_price),
               }))
-            : [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cached_output_price: '' }],
+            : [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       });
     } else {
       reset({
@@ -182,9 +186,10 @@ export function ModelForm({
         output_price: '',
         per_request_price: '',
         per_image_price: '',
-        tiers: [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cached_output_price: '' }],
+        tiers: [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
         cache_billing_enabled: false,
         cached_input_price: '',
+        cache_creation_input_price: '',
         cached_output_price: '',
       });
     }
@@ -225,6 +230,7 @@ export function ModelForm({
         submitData.tiered_pricing = null;
         submitData.cache_billing_enabled = null;
         submitData.cached_input_price = null;
+        submitData.cache_creation_input_price = null;
         submitData.cached_output_price = null;
       } else if (billingMode === 'per_image') {
         const perImg = data.per_image_price.trim();
@@ -235,6 +241,7 @@ export function ModelForm({
         submitData.tiered_pricing = null;
         submitData.cache_billing_enabled = null;
         submitData.cached_input_price = null;
+        submitData.cache_creation_input_price = null;
         submitData.cached_output_price = null;
       } else if (billingMode === 'token_tiered') {
         submitData.tiered_pricing = (data.tiers || []).map((t) => {
@@ -244,6 +251,7 @@ export function ModelForm({
             input_price: Number(t.input_price || '0'),
             output_price: Number(t.output_price || '0'),
             cached_input_price: data.cache_billing_enabled && t.cached_input_price.trim() ? Number(t.cached_input_price) : undefined,
+            cache_creation_input_price: data.cache_billing_enabled && t.cache_creation_input_price.trim() ? Number(t.cache_creation_input_price) : undefined,
             cached_output_price: data.cache_billing_enabled && t.cached_output_price.trim() ? Number(t.cached_output_price) : undefined,
           };
         });
@@ -253,6 +261,7 @@ export function ModelForm({
         submitData.output_price = null;
         submitData.cache_billing_enabled = data.cache_billing_enabled ?? false;
         submitData.cached_input_price = null;
+        submitData.cache_creation_input_price = null;
         submitData.cached_output_price = null;
       } else {
         // token_flat
@@ -265,6 +274,7 @@ export function ModelForm({
         submitData.tiered_pricing = null;
         submitData.cache_billing_enabled = data.cache_billing_enabled ?? false;
         submitData.cached_input_price = data.cache_billing_enabled && data.cached_input_price.trim() ? Number(data.cached_input_price) : null;
+        submitData.cache_creation_input_price = data.cache_billing_enabled && data.cache_creation_input_price.trim() ? Number(data.cache_creation_input_price) : null;
         submitData.cached_output_price = data.cache_billing_enabled && data.cached_output_price.trim() ? Number(data.cached_output_price) : null;
       }
     } else {
@@ -276,6 +286,7 @@ export function ModelForm({
       submitData.tiered_pricing = null;
       submitData.cache_billing_enabled = null;
       submitData.cached_input_price = null;
+      submitData.cache_creation_input_price = null;
       submitData.cached_output_price = null;
     }
 

--- a/frontend/src/components/models/ModelProviderBillingFields.tsx
+++ b/frontend/src/components/models/ModelProviderBillingFields.tsx
@@ -27,6 +27,7 @@ interface TierInputValue {
   input_price: string;
   output_price: string;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
 }
 
@@ -38,6 +39,7 @@ type BillingFormValues = FieldValues & {
   tiers: TierInputValue[];
   cache_billing_enabled: boolean;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
 };
 
@@ -225,7 +227,7 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
                 </div>
                 {/* Row 2: Cached prices, aligned under input/output columns */}
                 {cacheBillingEnabled && (
-                  <div className="grid grid-cols-7 gap-2 items-end">
+                  <div className="grid grid-cols-8 gap-2 items-end">
                     <div className="col-span-2" />
                     <div className="col-span-2 space-y-1">
                       <Label className="text-muted-foreground">{t('providerForm.tierCachedInputPrice')}</Label>
@@ -238,6 +240,16 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
                       />
                     </div>
                     <div className="col-span-2 space-y-1">
+                      <Label className="text-muted-foreground">{t('providerForm.tierCacheCreationInputPrice')}</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        step="0.0001"
+                        placeholder={t('providerForm.cachedPricePlaceholder')}
+                        {...register(`tiers.${idx}.cache_creation_input_price` as Path<TFormValues>)}
+                      />
+                    </div>
+                    <div className="col-span-2 space-y-1">
                       <Label className="text-muted-foreground">{t('providerForm.tierCachedOutputPrice')}</Label>
                       <Input
                         type="number"
@@ -247,7 +259,6 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
                         {...register(`tiers.${idx}.cached_output_price` as Path<TFormValues>)}
                       />
                     </div>
-                    <div className="col-span-1" />
                   </div>
                 )}
               </div>
@@ -256,7 +267,7 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
               type="button"
               variant="outline"
               onClick={() =>
-                appendTier({ max_input_tokens: '', input_price: '', output_price: '', cached_input_price: '', cached_output_price: '' })
+                appendTier({ max_input_tokens: '', input_price: '', output_price: '', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' })
               }
             >
               {t('providerForm.addTier')}
@@ -288,7 +299,7 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
             </div>
           </div>
           {cacheBillingEnabled && (
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-3 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="cached_input_price">{t('providerForm.cachedInputPrice')}</Label>
                 <Input
@@ -298,6 +309,17 @@ export function ModelProviderBillingFields<TFormValues extends BillingFormValues
                   step="0.0001"
                   placeholder={t('providerForm.cachedPricePlaceholder')}
                   {...register('cached_input_price' as Path<TFormValues>)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cache_creation_input_price">{t('providerForm.cacheCreationInputPrice')}</Label>
+                <Input
+                  id="cache_creation_input_price"
+                  type="number"
+                  min={0}
+                  step="0.0001"
+                  placeholder={t('providerForm.cachedPricePlaceholder')}
+                  {...register('cache_creation_input_price' as Path<TFormValues>)}
                 />
               </div>
               <div className="space-y-2">

--- a/frontend/src/components/models/ModelProviderForm.tsx
+++ b/frontend/src/components/models/ModelProviderForm.tsx
@@ -90,10 +90,11 @@ interface FormData {
   // per_image
   per_image_price: string;
   // token_tiered
-  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cached_output_price: string }>;
+  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cache_creation_input_price: string; cached_output_price: string }>;
   // cache billing
   cache_billing_enabled: boolean;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
   priority: number;
   weight: number;
@@ -138,9 +139,10 @@ export function ModelProviderForm({
       output_price: '',
       per_request_price: '',
       per_image_price: '',
-      tiers: [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '', output_price: '', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
       priority: 0,
       weight: 1,
@@ -217,6 +219,7 @@ export function ModelProviderForm({
             : String(mapping.per_image_price),
         cache_billing_enabled: !!mapping.cache_billing_enabled,
         cached_input_price: mapping.cached_input_price === null || mapping.cached_input_price === undefined ? '' : String(mapping.cached_input_price),
+        cache_creation_input_price: mapping.cache_creation_input_price === null || mapping.cache_creation_input_price === undefined ? '' : String(mapping.cache_creation_input_price),
         cached_output_price: mapping.cached_output_price === null || mapping.cached_output_price === undefined ? '' : String(mapping.cached_output_price),
         tiers:
           mapping.tiered_pricing && mapping.tiered_pricing.length > 0
@@ -228,6 +231,7 @@ export function ModelProviderForm({
                 input_price: String(t.input_price),
                 output_price: String(t.output_price),
                 cached_input_price: t.cached_input_price === null || t.cached_input_price === undefined ? '' : String(t.cached_input_price),
+                cache_creation_input_price: t.cache_creation_input_price === null || t.cache_creation_input_price === undefined ? '' : String(t.cache_creation_input_price),
                 cached_output_price: t.cached_output_price === null || t.cached_output_price === undefined ? '' : String(t.cached_output_price),
               }))
             : [
@@ -242,6 +246,7 @@ export function ModelProviderForm({
                       ? '0'
                       : String(mapping.output_price),
                   cached_input_price: '',
+                  cache_creation_input_price: '',
                   cached_output_price: '',
                 },
               ],
@@ -273,11 +278,13 @@ export function ModelProviderForm({
             input_price: fallbackInputPrice,
             output_price: fallbackOutputPrice,
             cached_input_price: '',
+            cache_creation_input_price: '',
             cached_output_price: '',
           },
         ],
         cache_billing_enabled: false,
         cached_input_price: '',
+        cache_creation_input_price: '',
         cached_output_price: '',
         priority: 0,
         weight: 1,
@@ -329,6 +336,7 @@ export function ModelProviderForm({
     setValue('tiers', formValues.tiers);
     setValue('cache_billing_enabled', formValues.cache_billing_enabled);
     setValue('cached_input_price', formValues.cached_input_price);
+    setValue('cache_creation_input_price', formValues.cache_creation_input_price);
     setValue('cached_output_price', formValues.cached_output_price);
   };
 
@@ -400,6 +408,7 @@ export function ModelProviderForm({
           input_price: inputPrice,
           output_price: outputPrice,
           cached_input_price: data.cache_billing_enabled && t.cached_input_price.trim() ? Number(t.cached_input_price) : null,
+          cache_creation_input_price: data.cache_billing_enabled && t.cache_creation_input_price.trim() ? Number(t.cache_creation_input_price) : null,
           cached_output_price: data.cache_billing_enabled && t.cached_output_price.trim() ? Number(t.cached_output_price) : null,
         };
       });
@@ -424,6 +433,7 @@ export function ModelProviderForm({
           submitData.tiered_pricing = null;
           submitData.cache_billing_enabled = null;
           submitData.cached_input_price = null;
+          submitData.cache_creation_input_price = null;
           submitData.cached_output_price = null;
         } else if (billingMode === 'per_request') {
           const perReq = data.per_request_price.trim();
@@ -447,6 +457,7 @@ export function ModelProviderForm({
           submitData.output_price = null;
           submitData.cache_billing_enabled = data.cache_billing_enabled ?? false;
           submitData.cached_input_price = null;
+          submitData.cache_creation_input_price = null;
           submitData.cached_output_price = null;
         } else {
           const flat = buildFlatPricing();
@@ -457,6 +468,7 @@ export function ModelProviderForm({
           submitData.tiered_pricing = null;
           submitData.cache_billing_enabled = data.cache_billing_enabled ?? false;
           submitData.cached_input_price = data.cache_billing_enabled && data.cached_input_price.trim() ? Number(data.cached_input_price) : null;
+          submitData.cache_creation_input_price = data.cache_billing_enabled && data.cache_creation_input_price.trim() ? Number(data.cache_creation_input_price) : null;
           submitData.cached_output_price = data.cache_billing_enabled && data.cached_output_price.trim() ? Number(data.cached_output_price) : null;
         }
       } else {
@@ -492,6 +504,7 @@ export function ModelProviderForm({
           submitData.tiered_pricing = null;
           submitData.cache_billing_enabled = null;
           submitData.cached_input_price = null;
+          submitData.cache_creation_input_price = null;
           submitData.cached_output_price = null;
         } else if (billingMode === 'per_request') {
           const perReq = data.per_request_price.trim();
@@ -515,6 +528,7 @@ export function ModelProviderForm({
           submitData.output_price = null;
           submitData.cache_billing_enabled = data.cache_billing_enabled ?? false;
           submitData.cached_input_price = null;
+          submitData.cache_creation_input_price = null;
           submitData.cached_output_price = null;
         } else {
           const flat = buildFlatPricing();
@@ -525,6 +539,7 @@ export function ModelProviderForm({
           submitData.tiered_pricing = null;
           submitData.cache_billing_enabled = data.cache_billing_enabled ?? false;
           submitData.cached_input_price = data.cache_billing_enabled && data.cached_input_price.trim() ? Number(data.cached_input_price) : null;
+          submitData.cache_creation_input_price = data.cache_billing_enabled && data.cache_creation_input_price.trim() ? Number(data.cache_creation_input_price) : null;
           submitData.cached_output_price = data.cache_billing_enabled && data.cached_output_price.trim() ? Number(data.cached_output_price) : null;
         }
       } else {

--- a/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
+++ b/frontend/src/components/providers/ProviderModelBulkUpgradeDialog.tsx
@@ -50,9 +50,10 @@ interface FormData {
   output_price: string;
   per_request_price: string;
   per_image_price: string;
-  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cached_output_price: string }>;
+  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cache_creation_input_price: string; cached_output_price: string }>;
   cache_billing_enabled: boolean;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
 }
 
@@ -64,9 +65,10 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       output_price: '0',
       per_request_price: '0',
       per_image_price: '0',
-      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -80,9 +82,10 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       output_price: '0',
       per_request_price: '0',
       per_image_price: '0',
-      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -94,9 +97,10 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       output_price: '0',
       per_request_price: String(mapping.per_request_price ?? 0),
       per_image_price: '0',
-      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -108,9 +112,10 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       output_price: '0',
       per_request_price: '0',
       per_image_price: String(mapping.per_image_price ?? 0),
-      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -126,9 +131,10 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
             input_price: String(tier.input_price ?? 0),
             output_price: String(tier.output_price ?? 0),
             cached_input_price: tier.cached_input_price != null ? String(tier.cached_input_price) : '',
+            cache_creation_input_price: tier.cache_creation_input_price != null ? String(tier.cache_creation_input_price) : '',
             cached_output_price: tier.cached_output_price != null ? String(tier.cached_output_price) : '',
           }))
-        : [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }];
+        : [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }];
 
     return {
       billing_mode: billingMode,
@@ -139,6 +145,7 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
       tiers,
       cache_billing_enabled: !!mapping.cache_billing_enabled,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -149,9 +156,10 @@ function buildDefaultPricing(mapping?: ModelMappingProvider | null): Omit<FormDa
     output_price: String(mapping.output_price ?? 0),
     per_request_price: '0',
     per_image_price: '0',
-    tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+    tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
     cache_billing_enabled: !!mapping.cache_billing_enabled,
     cached_input_price: mapping.cached_input_price != null ? String(mapping.cached_input_price) : '',
+    cache_creation_input_price: mapping.cache_creation_input_price != null ? String(mapping.cache_creation_input_price) : '',
     cached_output_price: mapping.cached_output_price != null ? String(mapping.cached_output_price) : '',
   };
 }
@@ -183,9 +191,10 @@ export function ProviderModelBulkUpgradeDialog({
       output_price: '0',
       per_request_price: '0',
       per_image_price: '0',
-      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '32768', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     },
   });
@@ -226,6 +235,7 @@ export function ProviderModelBulkUpgradeDialog({
       tiered_pricing: null,
       cache_billing_enabled: null,
       cached_input_price: null,
+      cache_creation_input_price: null,
       cached_output_price: null,
     };
 
@@ -241,6 +251,7 @@ export function ProviderModelBulkUpgradeDialog({
         input_price: Number(tier.input_price.trim() || '0'),
         output_price: Number(tier.output_price.trim() || '0'),
         cached_input_price: data.cache_billing_enabled && tier.cached_input_price.trim() ? Number(tier.cached_input_price) : undefined,
+        cache_creation_input_price: data.cache_billing_enabled && tier.cache_creation_input_price.trim() ? Number(tier.cache_creation_input_price) : undefined,
         cached_output_price: data.cache_billing_enabled && tier.cached_output_price.trim() ? Number(tier.cached_output_price) : undefined,
       }));
       payload.cache_billing_enabled = data.cache_billing_enabled || null;
@@ -249,6 +260,7 @@ export function ProviderModelBulkUpgradeDialog({
       payload.output_price = Number(data.output_price.trim() || '0');
       payload.cache_billing_enabled = data.cache_billing_enabled || null;
       payload.cached_input_price = data.cache_billing_enabled && data.cached_input_price.trim() ? Number(data.cached_input_price) : null;
+      payload.cache_creation_input_price = data.cache_billing_enabled && data.cache_creation_input_price.trim() ? Number(data.cache_creation_input_price) : null;
       payload.cached_output_price = data.cache_billing_enabled && data.cached_output_price.trim() ? Number(data.cached_output_price) : null;
     }
 

--- a/frontend/src/lib/__tests__/billing.test.ts
+++ b/frontend/src/lib/__tests__/billing.test.ts
@@ -50,7 +50,11 @@ describe('buildBillingSubmitData', () => {
     output_price: '15.0',
     per_request_price: '0.05',
     per_image_price: '0.04',
-    tiers: [{ max_input_tokens: '32768', input_price: '1.0', output_price: '2.0' }],
+    tiers: [{ max_input_tokens: '32768', input_price: '1.0', output_price: '2.0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
+    cache_billing_enabled: false,
+    cached_input_price: '',
+    cache_creation_input_price: '',
+    cached_output_price: '',
   };
 
   it('non-billing model type returns all nulls', () => {
@@ -109,7 +113,7 @@ describe('buildBillingSubmitData', () => {
     );
     expect(result.billing_mode).toBe('token_tiered');
     expect(result.tiered_pricing).toEqual([
-      { max_input_tokens: 32768, input_price: 1.0, output_price: 2.0 },
+      { max_input_tokens: 32768, input_price: 1.0, output_price: 2.0, cached_input_price: null, cache_creation_input_price: null, cached_output_price: null },
     ]);
     expect(result.per_request_price).toBeNull();
     expect(result.per_image_price).toBeNull();
@@ -122,12 +126,12 @@ describe('buildBillingSubmitData', () => {
       {
         ...baseValues,
         billing_mode: 'token_tiered',
-        tiers: [{ max_input_tokens: '', input_price: '3.0', output_price: '4.0' }],
+        tiers: [{ max_input_tokens: '', input_price: '3.0', output_price: '4.0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       },
       true,
     );
     expect(result.tiered_pricing).toEqual([
-      { max_input_tokens: null, input_price: 3.0, output_price: 4.0 },
+      { max_input_tokens: null, input_price: 3.0, output_price: 4.0, cached_input_price: null, cache_creation_input_price: null, cached_output_price: null },
     ]);
   });
 

--- a/frontend/src/lib/__tests__/modelProviderPricingHistory.test.ts
+++ b/frontend/src/lib/__tests__/modelProviderPricingHistory.test.ts
@@ -19,6 +19,7 @@ describe('getPriceHistoryFormValues', () => {
       resolved_cache_billing_enabled: true,
       resolved_cached_input_price: 0.05,
       resolved_cached_output_price: 0.2,
+      resolved_cache_creation_input_price: 0.075,
       priority: 0,
       weight: 1,
       is_active: true,
@@ -32,9 +33,10 @@ describe('getPriceHistoryFormValues', () => {
       output_price: '0.6',
       per_request_price: '0',
       per_image_price: '0',
-      tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: true,
       cached_input_price: '0.05',
+      cache_creation_input_price: '0.075',
       cached_output_price: '0.2',
     });
   });
@@ -54,6 +56,7 @@ describe('getPriceHistoryFormValues', () => {
           input_price: 1,
           output_price: 2,
           cached_input_price: 0.5,
+          cache_creation_input_price: 0.75,
           cached_output_price: 1,
         },
       ],
@@ -77,11 +80,13 @@ describe('getPriceHistoryFormValues', () => {
           input_price: '1',
           output_price: '2',
           cached_input_price: '0.5',
+          cache_creation_input_price: '0.75',
           cached_output_price: '1',
         },
       ],
       cache_billing_enabled: true,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     });
   });

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -11,6 +11,7 @@ import {
   LogCostStatsResponse,
   PaginatedResponse,
   RetryLogResponse,
+  ConvertedRequestResponse,
   LogPlaygroundExecuteRequest,
 } from '@/types';
 import { getStoredAdminToken } from './client';
@@ -48,6 +49,19 @@ export async function retryLog(id: number): Promise<RetryLogResponse> {
   return post<RetryLogResponse>(`${BASE_URL}/${id}/retry`, undefined, {
     timeout: RETRY_TIMEOUT_MS,
   });
+}
+
+/**
+ * Get the full (non-truncated) upstream converted request body.
+ *
+ * The stored converted_request_body is truncated for storage; this endpoint
+ * re-runs the protocol conversion on the server to return the complete body.
+ * @param id - Log ID
+ */
+export async function getConvertedRequest(
+  id: number
+): Promise<ConvertedRequestResponse> {
+  return get<ConvertedRequestResponse>(`${BASE_URL}/${id}/converted-request`);
 }
 
 export async function executeLogPlaygroundRequest(

--- a/frontend/src/lib/billing.ts
+++ b/frontend/src/lib/billing.ts
@@ -33,10 +33,12 @@ export interface BillingSubmitData {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled: boolean | null;
   cached_input_price: number | null;
+  cache_creation_input_price: number | null;
   cached_output_price: number | null;
 }
 
@@ -46,9 +48,10 @@ interface BillingFormValues {
   output_price: string;
   per_request_price: string;
   per_image_price: string;
-  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cached_output_price: string }>;
+  tiers: Array<{ max_input_tokens: string; input_price: string; output_price: string; cached_input_price: string; cache_creation_input_price: string; cached_output_price: string }>;
   cache_billing_enabled: boolean;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
 }
 
@@ -70,6 +73,7 @@ export function buildBillingSubmitData(
       tiered_pricing: null,
       cache_billing_enabled: null,
       cached_input_price: null,
+      cache_creation_input_price: null,
       cached_output_price: null,
     };
   }
@@ -87,6 +91,7 @@ export function buildBillingSubmitData(
       tiered_pricing: null,
       cache_billing_enabled: null,
       cached_input_price: null,
+      cache_creation_input_price: null,
       cached_output_price: null,
     };
   }
@@ -102,6 +107,7 @@ export function buildBillingSubmitData(
       tiered_pricing: null,
       cache_billing_enabled: null,
       cached_input_price: null,
+      cache_creation_input_price: null,
       cached_output_price: null,
     };
   }
@@ -117,6 +123,8 @@ export function buildBillingSubmitData(
           output_price: Number(t.output_price || '0'),
           cached_input_price: values.cache_billing_enabled && t.cached_input_price.trim()
             ? Number(t.cached_input_price) : null,
+          cache_creation_input_price: values.cache_billing_enabled && t.cache_creation_input_price.trim()
+            ? Number(t.cache_creation_input_price) : null,
           cached_output_price: values.cache_billing_enabled && t.cached_output_price.trim()
             ? Number(t.cached_output_price) : null,
         };
@@ -127,6 +135,7 @@ export function buildBillingSubmitData(
       output_price: null,
       cache_billing_enabled: values.cache_billing_enabled || null,
       cached_input_price: null,
+      cache_creation_input_price: null,
       cached_output_price: null,
     };
   }
@@ -144,6 +153,8 @@ export function buildBillingSubmitData(
     cache_billing_enabled: values.cache_billing_enabled || null,
     cached_input_price: values.cache_billing_enabled && values.cached_input_price.trim()
       ? Number(values.cached_input_price) : null,
+    cache_creation_input_price: values.cache_billing_enabled && values.cache_creation_input_price.trim()
+      ? Number(values.cache_creation_input_price) : null,
     cached_output_price: values.cache_billing_enabled && values.cached_output_price.trim()
       ? Number(values.cached_output_price) : null,
   };

--- a/frontend/src/lib/modelProviderPricingHistory.ts
+++ b/frontend/src/lib/modelProviderPricingHistory.ts
@@ -18,10 +18,12 @@ export interface ProviderBillingFormValues {
     input_price: string;
     output_price: string;
     cached_input_price: string;
+    cache_creation_input_price: string;
     cached_output_price: string;
   }>;
   cache_billing_enabled: boolean;
   cached_input_price: string;
+  cache_creation_input_price: string;
   cached_output_price: string;
 }
 
@@ -41,9 +43,10 @@ export function getPriceHistoryFormValues(
       output_price: '0',
       per_request_price: String(item.resolved_per_request_price ?? item.per_request_price ?? 0),
       per_image_price: '0',
-      tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -55,9 +58,10 @@ export function getPriceHistoryFormValues(
       output_price: '0',
       per_request_price: '0',
       per_image_price: String(item.resolved_per_image_price ?? item.per_image_price ?? 0),
-      tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+      tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: false,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -83,14 +87,19 @@ export function getPriceHistoryFormValues(
                 tier.cached_input_price === null || tier.cached_input_price === undefined
                   ? ''
                   : String(tier.cached_input_price),
+              cache_creation_input_price:
+                tier.cache_creation_input_price === null || tier.cache_creation_input_price === undefined
+                  ? ''
+                  : String(tier.cache_creation_input_price),
               cached_output_price:
                 tier.cached_output_price === null || tier.cached_output_price === undefined
                   ? ''
                   : String(tier.cached_output_price),
             }))
-          : [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+          : [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
       cache_billing_enabled: !!item.resolved_cache_billing_enabled,
       cached_input_price: '',
+      cache_creation_input_price: '',
       cached_output_price: '',
     };
   }
@@ -101,12 +110,16 @@ export function getPriceHistoryFormValues(
     output_price: String(item.resolved_output_price ?? item.output_price ?? 0),
     per_request_price: '0',
     per_image_price: '0',
-    tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cached_output_price: '' }],
+    tiers: [{ max_input_tokens: '', input_price: '0', output_price: '0', cached_input_price: '', cache_creation_input_price: '', cached_output_price: '' }],
     cache_billing_enabled: !!item.resolved_cache_billing_enabled,
     cached_input_price:
       item.resolved_cached_input_price === null || item.resolved_cached_input_price === undefined
         ? ''
         : String(item.resolved_cached_input_price),
+    cache_creation_input_price:
+      item.resolved_cache_creation_input_price === null || item.resolved_cache_creation_input_price === undefined
+        ? ''
+        : String(item.resolved_cache_creation_input_price),
     cached_output_price:
       item.resolved_cached_output_price === null || item.resolved_cached_output_price === undefined
         ? ''

--- a/frontend/src/types/log.ts
+++ b/frontend/src/types/log.ts
@@ -59,6 +59,14 @@ export interface RetryLogResponse {
   trace_id?: string | null;
 }
 
+export interface ConvertedRequestResponse {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  converted_request_body?: Record<string, any> | null;
+  upstream_url?: string | null;
+  request_method?: string | null;
+  supplier_protocol?: string | null;
+}
+
 export interface LogPlaygroundExecuteRequest {
   protocol: string;
   request_path?: string | null;

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -30,10 +30,12 @@ export interface ModelMapping {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
   provider_count?: number;            // Associated provider count
   active_provider_count?: number;     // Associated active provider count
@@ -60,10 +62,12 @@ export interface ModelMappingProvider {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   resolved_cache_billing_enabled?: boolean | null;
   resolved_cached_input_price?: number | null;
+  resolved_cache_creation_input_price?: number | null;
   resolved_cached_output_price?: number | null;
   target_model_name: string;          // Target model name for this provider
   provider_rules?: RuleSet | null;    // Provider level rules
@@ -82,10 +86,12 @@ export interface ModelMappingProvider {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
   priority: number;
   weight: number;
@@ -111,10 +117,12 @@ export interface ModelMappingCreate {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
 }
 
@@ -134,10 +142,12 @@ export interface ModelMappingUpdate {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
 }
 
@@ -157,10 +167,12 @@ export interface ModelMappingProviderCreate {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
   priority?: number;
   weight?: number;
@@ -181,10 +193,12 @@ export interface ModelMappingProviderUpdate {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
   priority?: number;
   weight?: number;
@@ -206,10 +220,12 @@ export interface ModelProviderBulkUpgradeRequest {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
 }
 
@@ -253,10 +269,12 @@ export interface ModelProviderExport {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
   priority?: number;
   weight?: number;
@@ -309,10 +327,12 @@ export interface ModelMatchProvider {
     input_price: number;
     output_price: number;
     cached_input_price?: number | null;
+    cache_creation_input_price?: number | null;
     cached_output_price?: number | null;
   }> | null;
   cache_billing_enabled?: boolean | null;
   cached_input_price?: number | null;
+  cache_creation_input_price?: number | null;
   cached_output_price?: number | null;
   model_input_price?: number | null;
   model_output_price?: number | null;


### PR DESCRIPTION
## Summary

Implements bidirectional protocol conversion between OpenAI and Anthropic APIs, enabling proxy requests to be forwarded to suppliers using a different protocol than the one requested by the user.

## Changes

### New Features
- **`backend/app/common/protocol_conversion.py`** – Core conversion module providing:
  - `convert_request_for_supplier`: Translates request body/path from user protocol (OpenAI/Anthropic) to supplier protocol
  - `convert_response_for_user`: Translates non-streaming response body back to user protocol
  - `convert_stream_for_user`: Async generator that translates SSE streaming responses between protocols
  - Leverages `litellm` (`AnthropicConfig`, `AnthropicExperimentalPassThroughConfig`) for format transformations

### Service Updates
- **`backend/app/services/proxy_service.py`** – Integrated protocol conversion into the proxy pipeline for both streaming and non-streaming responses

### Dependencies
- **`backend/pyproject.toml`** / **`backend/requirements.txt`** – Added `litellm` as a required dependency

### Tests
- **`test_protocol_conversion.py`** – 194-line unit test suite covering request/response/stream conversion in both directions
- **`test_proxy_service_protocol_matching.py`** – Refactored existing protocol matching tests (~70 lines reduced)

## Supported Conversions

| User Protocol | Supplier Protocol | Request Path |
|---|---|---|
| OpenAI | Anthropic | `/v1/chat/completions` → `/v1/messages` |
| Anthropic | OpenAI | `/v1/messages` → `/v1/chat/completions` |
| Same | Same | Pass-through (no conversion) |