### PR TITLE
feat: add protocol conversion between OpenAI and Anthropic

### DIFF
--- a/backend/app/common/costs.py
+++ b/backend/app/common/costs.py
@@ -434,19 +434,8 @@ def calculate_cost(
         cached_input_tokens or cached_output_tokens or cache_creation_input_tokens
     ):
         # Split input tokens: read-cached + write-creation + non-cached.
-        #
-        # Two upstream conventions exist:
-        #
-        # - OpenAI (cache_tokens_separate=False): cached_tokens ⊆ prompt_tokens.
-        #   The reported input_tokens already includes cached/write tokens, so
-        #   each is capped at in_tokens (and their combined sum capped too) and
-        #   subtracted out to derive the non-cached remainder.
-        #
-        # - Anthropic (cache_tokens_separate=True): cache_read_input_tokens and
-        #   cache_creation_input_tokens are reported separately from and in
-        #   addition to input_tokens. They must be billed in full alongside the
-        #   full input_tokens (no cap, no subtraction), otherwise the much
-        #   larger cache token counts collapse to ~0 against a tiny input_tokens.
+        # cache_tokens_separate remains for older Anthropic-style callers where
+        # input_tokens is the uncached count instead of the total prompt count.
         if cache_tokens_separate:
             c_in = int(cached_input_tokens or 0)
             c_create = int(cache_creation_input_tokens or 0)

--- a/backend/app/common/protocol/converters.py
+++ b/backend/app/common/protocol/converters.py
@@ -84,6 +84,45 @@ _OPENAI_IMAGE_PATHS = {
 }
 
 
+def _usage_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return default
+
+
+def _anthropic_usage_total_input(usage: Dict[str, Any]) -> int:
+    return (
+        _usage_int(usage.get("input_tokens"))
+        + _usage_int(usage.get("cache_creation_input_tokens"))
+        + _usage_int(usage.get("cache_read_input_tokens"))
+    )
+
+
+def _openai_usage_cache_read(usage: Dict[str, Any]) -> int:
+    details = (
+        usage.get("input_tokens_details")
+        or usage.get("prompt_tokens_details")
+        or {}
+    )
+    if isinstance(details, dict):
+        return _usage_int(details.get("cached_tokens"))
+    return _usage_int(usage.get("cached_tokens"))
+
+
+def _openai_usage_uncached_input(usage: Dict[str, Any]) -> int:
+    prompt_tokens = _usage_int(
+        usage.get("prompt_tokens"),
+        _usage_int(usage.get("input_tokens")),
+    )
+    return max(prompt_tokens - _openai_usage_cache_read(usage), 0)
+
+
 def _protocol_to_sdk(protocol: Protocol) -> "SDKProtocol":
     """Convert internal Protocol to SDK Protocol."""
     mapping = {
@@ -1625,6 +1664,40 @@ class SDKResponseConverter(IResponseConverter):
                 options=options,
             )
 
+            usage = body.get("usage") if isinstance(body, dict) else None
+            if isinstance(usage, dict):
+                if self._source == Protocol.ANTHROPIC and self._target in (
+                    Protocol.OPENAI,
+                    Protocol.OPENAI_RESPONSES,
+                ):
+                    prompt_tokens = _anthropic_usage_total_input(usage)
+                    output_tokens = _usage_int(usage.get("output_tokens"))
+                    converted["usage"] = {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": output_tokens,
+                        "total_tokens": prompt_tokens + output_tokens,
+                    }
+                    cache_read = _usage_int(usage.get("cache_read_input_tokens"))
+                    if cache_read:
+                        converted["usage"]["prompt_tokens_details"] = {
+                            "cached_tokens": cache_read,
+                        }
+                elif self._source in (
+                    Protocol.OPENAI,
+                    Protocol.OPENAI_RESPONSES,
+                ) and self._target == Protocol.ANTHROPIC:
+                    output_tokens = _usage_int(
+                        usage.get("completion_tokens"),
+                        _usage_int(usage.get("output_tokens")),
+                    )
+                    converted["usage"] = {
+                        "input_tokens": _openai_usage_uncached_input(usage),
+                        "output_tokens": output_tokens,
+                    }
+                    cache_read = _openai_usage_cache_read(usage)
+                    if cache_read:
+                        converted["usage"]["cache_read_input_tokens"] = cache_read
+
             return converted
 
         except Exception as e:
@@ -1790,7 +1863,7 @@ class SDKStreamConverter(IStreamConverter):
                         # Extract initial usage from message_start
                         initial_usage = message.get("usage")
                         if isinstance(initial_usage, dict):
-                            input_tokens = initial_usage.get("input_tokens", 0)
+                            input_tokens = _anthropic_usage_total_input(initial_usage)
                             # Initialize final_usage with input_tokens from message_start
                             final_usage = {
                                 "prompt_tokens": input_tokens,
@@ -1903,19 +1976,18 @@ class SDKStreamConverter(IStreamConverter):
                     usage_data = data.get("usage")
                     if isinstance(usage_data, dict):
                         # Convert Anthropic usage format to OpenAI format
-                        input_tokens = usage_data.get("input_tokens", 0)
-                        output_tokens = usage_data.get("output_tokens", 0)
+                        input_tokens = _anthropic_usage_total_input(usage_data)
+                        output_tokens = _usage_int(usage_data.get("output_tokens"))
                         final_usage = {
                             "prompt_tokens": input_tokens,
                             "completion_tokens": output_tokens,
                             "total_tokens": input_tokens + output_tokens,
                         }
                         # Include cache tokens if available
-                        if "cache_creation_input_tokens" in usage_data:
+                        cache_read = _usage_int(usage_data.get("cache_read_input_tokens"))
+                        if cache_read:
                             final_usage["prompt_tokens_details"] = {
-                                "cached_tokens": usage_data.get(
-                                    "cache_read_input_tokens", 0
-                                ),
+                                "cached_tokens": cache_read,
                             }
 
                     yield _encode_sse_json(
@@ -2156,14 +2228,23 @@ class SDKStreamConverter(IStreamConverter):
             ):
                 usage_payload: Dict[str, Any] = {"output_tokens": 0}
                 if last_usage is not None:
+                    cache_read_tokens = (
+                        last_usage.cache_read_input_tokens
+                        if last_usage.cache_read_input_tokens is not None
+                        else last_usage.cached_tokens
+                    )
+                    input_tokens = max(
+                        (last_usage.input_tokens or 0)
+                        - (cache_read_tokens or 0)
+                        - (last_usage.cache_creation_input_tokens or 0),
+                        0,
+                    )
                     usage_payload = {
-                        "input_tokens": last_usage.input_tokens or 0,
+                        "input_tokens": input_tokens,
                         "output_tokens": last_usage.output_tokens or 0,
                     }
-                    if last_usage.cached_tokens:
-                        usage_payload["cache_read_input_tokens"] = (
-                            last_usage.cached_tokens
-                        )
+                    if cache_read_tokens:
+                        usage_payload["cache_read_input_tokens"] = cache_read_tokens
                     if last_usage.cache_creation_input_tokens:
                         usage_payload["cache_creation_input_tokens"] = (
                             last_usage.cache_creation_input_tokens

--- a/backend/app/common/stream_usage.py
+++ b/backend/app/common/stream_usage.py
@@ -7,7 +7,7 @@ Used when upstream returns SSE (text/event-stream) to extract incremental text f
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, Optional
 
 from app.common.token_counter import get_token_counter
@@ -72,6 +72,39 @@ class StreamUsageResult:
     input_tokens: Optional[int]
     upstream_reported_output_tokens: Optional[int]
     usage_details: Optional[dict[str, Any]]
+
+
+def _merge_usage_details(
+    previous: Optional[UsageDetails],
+    current: UsageDetails,
+) -> UsageDetails:
+    if previous is None:
+        return current
+
+    values: dict[str, Any] = {}
+    for field in fields(UsageDetails):
+        name = field.name
+        old_value = getattr(previous, name)
+        new_value = getattr(current, name)
+        values[name] = new_value if new_value is not None else old_value
+
+    old_raw = previous.raw_usage
+    new_raw = current.raw_usage
+    if isinstance(old_raw, dict) and isinstance(new_raw, dict):
+        values["raw_usage"] = {**old_raw, **new_raw}
+
+    old_extra = previous.extra_usage
+    new_extra = current.extra_usage
+    if isinstance(old_extra, dict) and isinstance(new_extra, dict):
+        values["extra_usage"] = {**old_extra, **new_extra}
+
+    if current.total_tokens is None:
+        input_tokens = values.get("input_tokens")
+        output_tokens = values.get("output_tokens")
+        if input_tokens is not None and output_tokens is not None:
+            values["total_tokens"] = input_tokens + output_tokens
+
+    return UsageDetails(**values)
 
 
 class StreamUsageAccumulator:
@@ -309,7 +342,7 @@ class StreamUsageAccumulator:
         details = extract_usage_details(data)
         if not details:
             return
-        self._usage_details = details
+        self._usage_details = _merge_usage_details(self._usage_details, details)
         if details.output_tokens is not None:
             self._upstream_output_tokens = details.output_tokens
         if details.input_tokens is not None:

--- a/backend/app/common/usage_extractor.py
+++ b/backend/app/common/usage_extractor.py
@@ -63,9 +63,12 @@ def _extract_usage_dict(obj: Any) -> tuple[dict[str, Any], str] | None:
 
 @dataclass(frozen=True)
 class UsageDetails:
+    # Normalized total prompt/input tokens. For Anthropic this is computed as
+    # input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
+    # Legacy/common cache-read alias. Prefer cache_read_input_tokens in new code.
     cached_tokens: Optional[int] = None
     cache_creation_input_tokens: Optional[int] = None
     cache_read_input_tokens: Optional[int] = None
@@ -94,6 +97,14 @@ def _safe_int(value: Any) -> Optional[int]:
     return None
 
 
+def _first_int(*values: Any) -> Optional[int]:
+    for value in values:
+        parsed = _safe_int(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
 def _normalize_usage(usage: dict[str, Any], usage_kind: str) -> UsageDetails:
     input_tokens = None
     output_tokens = None
@@ -116,6 +127,7 @@ def _normalize_usage(usage: dict[str, Any], usage_kind: str) -> UsageDetails:
         output_tokens = _safe_int(usage.get("candidatesTokenCount"))
         total_tokens = _safe_int(usage.get("totalTokenCount"))
         cached_tokens = _safe_int(usage.get("cachedContentTokenCount"))
+        cache_read_input_tokens = cached_tokens
 
         # Parse Gemini modality details: promptTokensDetails
         prompt_details = usage.get("promptTokensDetails")
@@ -148,13 +160,19 @@ def _normalize_usage(usage: dict[str, Any], usage_kind: str) -> UsageDetails:
         # Map thoughtsTokenCount to reasoning_tokens
         reasoning_tokens = _safe_int(usage.get("thoughtsTokenCount"))
     else:
-        input_tokens = _safe_int(usage.get("prompt_tokens") or usage.get("input_tokens"))
-        output_tokens = _safe_int(usage.get("completion_tokens") or usage.get("output_tokens"))
+        raw_prompt_tokens = _first_int(
+            usage.get("prompt_tokens"),
+            usage.get("input_tokens"),
+        )
+        output_tokens = _first_int(usage.get("completion_tokens"), usage.get("output_tokens"))
         total_tokens = _safe_int(usage.get("total_tokens"))
 
         cached_tokens = _safe_int(usage.get("cached_tokens"))
         cache_creation_input_tokens = _safe_int(usage.get("cache_creation_input_tokens"))
         cache_read_input_tokens = _safe_int(usage.get("cache_read_input_tokens"))
+        has_explicit_anthropic_cache_fields = (
+            "cache_creation_input_tokens" in usage or "cache_read_input_tokens" in usage
+        )
 
         input_details = (
             usage.get("input_tokens_details")
@@ -167,7 +185,11 @@ def _normalize_usage(usage: dict[str, Any], usage_kind: str) -> UsageDetails:
             or usage.get("output_token_details")
         )
         if isinstance(input_details, dict):
-            cached_tokens = cached_tokens or _safe_int(input_details.get("cached_tokens"))
+            cached_tokens = (
+                cached_tokens
+                if cached_tokens is not None
+                else _safe_int(input_details.get("cached_tokens"))
+            )
             input_audio_tokens = _safe_int(input_details.get("audio_tokens"))
             input_image_tokens = _safe_int(input_details.get("image_tokens"))
             input_video_tokens = _safe_int(input_details.get("video_tokens"))
@@ -179,6 +201,24 @@ def _normalize_usage(usage: dict[str, Any], usage_kind: str) -> UsageDetails:
             output_video_tokens = _safe_int(output_details.get("video_tokens"))
             reasoning_tokens = reasoning_tokens or _safe_int(output_details.get("reasoning_tokens"))
             tool_tokens = tool_tokens or _safe_int(output_details.get("tool_tokens"))
+
+        if cache_read_input_tokens is None:
+            cache_read_input_tokens = cached_tokens
+        if cached_tokens is None:
+            cached_tokens = cache_read_input_tokens
+
+        # Anthropic reports top-level input_tokens as regular input plus
+        # top-level cache read/write fields as additive input. OpenAI Responses
+        # uses nested input_tokens_details.cached_tokens, so it does not enter
+        # this branch.
+        if has_explicit_anthropic_cache_fields and "prompt_tokens" not in usage:
+            input_tokens = (
+                (raw_prompt_tokens or 0)
+                + (cache_creation_input_tokens or 0)
+                + (cache_read_input_tokens or 0)
+            )
+        else:
+            input_tokens = raw_prompt_tokens
 
     if total_tokens is None and input_tokens is not None and output_tokens is not None:
         total_tokens = input_tokens + output_tokens

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -884,6 +884,7 @@ class ProxyService:
             model_cache_billing_enabled=getattr(model_mapping, "cache_billing_enabled", None),
             model_cached_input_price=getattr(model_mapping, "cached_input_price", None),
             model_cached_output_price=getattr(model_mapping, "cached_output_price", None),
+            model_cache_creation_input_price=getattr(model_mapping, "cache_creation_input_price", None),
             provider_billing_mode=provider_mapping.billing_mode
             if provider_mapping
             else None,
@@ -918,21 +919,13 @@ class ProxyService:
         # Extract cached tokens from usage details
         cached_input_tokens = None
         cache_creation_input_tokens = None
-        cache_tokens_separate = False
         if usage_details:
             cached_input_tokens = (
-                usage_details.get("cached_tokens")
-                or usage_details.get("cache_read_input_tokens")
+                usage_details.get("cache_read_input_tokens")
+                if usage_details.get("cache_read_input_tokens") is not None
+                else usage_details.get("cached_tokens")
             )
             cache_creation_input_tokens = usage_details.get("cache_creation_input_tokens")
-            # Anthropic reports cache_read/creation tokens separately from (and in
-            # addition to) input_tokens, unlike OpenAI where cached_tokens are a
-            # subset of prompt_tokens. Detect the Anthropic-style keys so billing
-            # does not cap the cache tokens against the much smaller input_tokens.
-            cache_tokens_separate = (
-                usage_details.get("cache_read_input_tokens") is not None
-                or usage_details.get("cache_creation_input_tokens") is not None
-            )
         cost = calculate_cost_from_billing(
             billing=billing,
             input_tokens=input_tokens,
@@ -940,7 +933,6 @@ class ProxyService:
             image_count=image_count,
             cached_input_tokens=cached_input_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
-            cache_tokens_separate=cache_tokens_separate,
         )
         log_data = RequestLogCreate(
             request_time=request_time,
@@ -1519,6 +1511,7 @@ class ProxyService:
                     model_cache_billing_enabled=getattr(model_mapping, "cache_billing_enabled", None),
                     model_cached_input_price=getattr(model_mapping, "cached_input_price", None),
                     model_cached_output_price=getattr(model_mapping, "cached_output_price", None),
+                    model_cache_creation_input_price=getattr(model_mapping, "cache_creation_input_price", None),
                     provider_billing_mode=provider_mapping.billing_mode
                     if provider_mapping
                     else None,
@@ -1553,19 +1546,13 @@ class ProxyService:
                 # Extract cached tokens from stream usage details
                 stream_cached_input_tokens = None
                 stream_cache_creation_input_tokens = None
-                stream_cache_tokens_separate = False
                 if usage_details:
                     stream_cached_input_tokens = (
-                        usage_details.get("cached_tokens")
-                        or usage_details.get("cache_read_input_tokens")
+                        usage_details.get("cache_read_input_tokens")
+                        if usage_details.get("cache_read_input_tokens") is not None
+                        else usage_details.get("cached_tokens")
                     )
                     stream_cache_creation_input_tokens = usage_details.get("cache_creation_input_tokens")
-                    # See non-stream path: Anthropic reports cache tokens as
-                    # additive/separate from input_tokens.
-                    stream_cache_tokens_separate = (
-                        usage_details.get("cache_read_input_tokens") is not None
-                        or usage_details.get("cache_creation_input_tokens") is not None
-                    )
                 cost = calculate_cost_from_billing(
                     billing=billing,
                     input_tokens=input_tokens,
@@ -1573,7 +1560,6 @@ class ProxyService:
                     image_count=image_count,
                     cached_input_tokens=stream_cached_input_tokens,
                     cache_creation_input_tokens=stream_cache_creation_input_tokens,
-                    cache_tokens_separate=stream_cache_tokens_separate,
                 )
                 raw_stream_text = (
                     b"".join(raw_stream_chunks).decode("utf-8", errors="replace")

--- a/backend/tests/unit/test_common/test_costs.py
+++ b/backend/tests/unit/test_common/test_costs.py
@@ -919,6 +919,40 @@ class TestSeparateCacheTokens:
         # Cache tokens collapse against input_tokens=1; only output is billed.
         assert cost.total_cost == 0.0155
 
+    def test_unified_usage_bills_anthropic_without_separate_flag(self):
+        """Normalized Anthropic usage derives regular input from total minus cache."""
+        cost = calculate_cost(
+            input_tokens=89_228,
+            output_tokens=616,
+            input_price=5.0,
+            output_price=25.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=87_041,
+            cached_input_price=0.5,
+            cache_creation_input_tokens=2_186,
+            cache_creation_input_price=10.0,
+        )
+        assert cost.input_cost == 0.0656
+        assert cost.output_cost == 0.0154
+        assert cost.total_cost == 0.081
+
+    def test_unified_openai_example(self):
+        """1429 prompt = 768 cache read + 661 regular input."""
+        cost = calculate_cost(
+            input_tokens=1429,
+            output_tokens=8,
+            input_price=5.0,
+            output_price=15.0,
+            cache_billing_enabled=True,
+            cached_input_tokens=768,
+            cached_input_price=1.0,
+        )
+        # input: ceil(768/1M*1) + ceil(661/1M*5) = 0.0008 + 0.0034
+        # output: ceil(8/1M*15) = 0.0002
+        assert cost.input_cost == 0.0042
+        assert cost.output_cost == 0.0002
+        assert cost.total_cost == 0.0044
+
 
 class TestResolveBillingCacheCreation:
     """resolve_billing correctly resolves cache_creation_input_price."""
@@ -1036,4 +1070,3 @@ class TestCalculateCostFromBillingWithCacheCreation:
         assert cost.input_cost == 4.0
         assert cost.cached_input_cost == 1.5
         assert cost.total_cost == 4.0
-

--- a/backend/tests/unit/test_common/test_protocol_conversion.py
+++ b/backend/tests/unit/test_common/test_protocol_conversion.py
@@ -580,7 +580,12 @@ def test_convert_response_openai_to_anthropic():
                     "finish_reason": "stop",
                 }
             ],
-            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 2,
+                "total_tokens": 7,
+                "prompt_tokens_details": {"cached_tokens": 4},
+            },
         },
     )
 
@@ -588,6 +593,8 @@ def test_convert_response_openai_to_anthropic():
     assert converted["role"] == "assistant"
     assert isinstance(converted["content"], list)
     assert converted["content"][0]["type"] == "text"
+    assert converted["usage"]["input_tokens"] == 1
+    assert converted["usage"]["cache_read_input_tokens"] == 4
 
 
 def test_convert_response_anthropic_to_openai():
@@ -603,14 +610,21 @@ def test_convert_response_anthropic_to_openai():
             "content": [{"type": "text", "text": "Hello"}],
             "stop_reason": "end_turn",
             "stop_sequence": None,
-            "usage": {"input_tokens": 1, "output_tokens": 2},
+            "usage": {
+                "input_tokens": 1,
+                "cache_creation_input_tokens": 3,
+                "cache_read_input_tokens": 4,
+                "output_tokens": 2,
+            },
         },
     )
 
     assert converted["object"] == "chat.completion"
     assert converted["choices"][0]["message"]["content"] == "Hello"
-    assert converted["usage"]["prompt_tokens"] == 1
+    assert converted["usage"]["prompt_tokens"] == 8
     assert converted["usage"]["completion_tokens"] == 2
+    assert converted["usage"]["total_tokens"] == 10
+    assert converted["usage"]["prompt_tokens_details"] == {"cached_tokens": 4}
 
 
 def test_convert_request_openai_responses_to_anthropic_with_max_output_tokens():
@@ -1987,6 +2001,7 @@ def test_convert_response_gemini_to_anthropic():
     assert converted["role"] == "assistant"
     assert isinstance(converted["content"], list)
     assert converted["content"][0]["type"] == "text"
+    assert converted["usage"]["input_tokens"] == 3
     assert "Hello from Gemini" in converted["content"][0]["text"]
 
 

--- a/backend/tests/unit/test_common/test_stream_usage.py
+++ b/backend/tests/unit/test_common/test_stream_usage.py
@@ -42,6 +42,11 @@ def test_openai_stream_prefers_upstream_reported_usage():
 def test_anthropic_stream_accumulates_text_and_uses_output_tokens():
     acc = StreamUsageAccumulator(protocol="anthropic", model="claude-3")
     chunks = [
+        (
+            b"data: {\"type\":\"message_start\",\"message\":{\"usage\":"
+            b"{\"input_tokens\":3,\"cache_creation_input_tokens\":2,"
+            b"\"cache_read_input_tokens\":5}}}\r\n\r\n"
+        ),
         b"data: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"Hi\"}}\r\n\r\n",
         b"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\r\n\r\n",
     ]
@@ -51,6 +56,11 @@ def test_anthropic_stream_accumulates_text_and_uses_output_tokens():
     result = acc.finalize()
     assert result.output_text == "Hi"
     assert result.output_tokens == 9
+    assert result.input_tokens == 10
+    assert result.usage_details is not None
+    assert result.usage_details["cache_read_input_tokens"] == 5
+    assert result.usage_details["cache_creation_input_tokens"] == 2
+    assert result.usage_details["total_tokens"] == 19
 
 
 def test_anthropic_stream_counts_thinking_delta_when_usage_missing():

--- a/backend/tests/unit/test_common/test_usage_extractor.py
+++ b/backend/tests/unit/test_common/test_usage_extractor.py
@@ -24,6 +24,7 @@ def test_extract_usage_details_openai_details_fields():
     assert details.input_tokens == 10
     assert details.output_tokens == 4
     assert details.cached_tokens == 2
+    assert details.cache_read_input_tokens == 2
     assert details.input_audio_tokens == 3
     assert details.output_image_tokens == 5
     assert details.reasoning_tokens == 1
@@ -40,8 +41,11 @@ def test_extract_usage_details_anthropic_cache_fields():
     }
     details = extract_usage_details(body)
     assert details is not None
+    assert details.input_tokens == 25
+    assert details.total_tokens == 30
     assert details.cache_creation_input_tokens == 3
     assert details.cache_read_input_tokens == 2
+    assert details.cached_tokens == 2
 
 
 def test_extract_usage_details_gemini_metadata():
@@ -59,6 +63,55 @@ def test_extract_usage_details_gemini_metadata():
     assert details.output_tokens == 6
     assert details.total_tokens == 14
     assert details.cached_tokens == 4
+    assert details.cache_read_input_tokens == 4
+
+
+def test_extract_usage_details_vendor_cache_examples():
+    openai = extract_usage_details(
+        {
+            "usage": {
+                "prompt_tokens": 1429,
+                "completion_tokens": 8,
+                "total_tokens": 1437,
+                "prompt_tokens_details": {"cached_tokens": 768},
+            }
+        }
+    )
+    assert openai is not None
+    assert openai.input_tokens == 1429
+    assert openai.cache_read_input_tokens == 768
+    assert openai.cache_creation_input_tokens is None
+
+    anthropic = extract_usage_details(
+        {
+            "usage": {
+                "input_tokens": 661,
+                "output_tokens": 8,
+                "cache_creation_input_tokens": 768,
+                "cache_read_input_tokens": 0,
+            }
+        }
+    )
+    assert anthropic is not None
+    assert anthropic.input_tokens == 1429
+    assert anthropic.cache_creation_input_tokens == 768
+    assert anthropic.cache_read_input_tokens == 0
+    assert anthropic.total_tokens == 1437
+
+    gemini = extract_usage_details(
+        {
+            "usageMetadata": {
+                "promptTokenCount": 1429,
+                "cachedContentTokenCount": 768,
+                "candidatesTokenCount": 8,
+                "totalTokenCount": 1437,
+            }
+        }
+    )
+    assert gemini is not None
+    assert gemini.input_tokens == 1429
+    assert gemini.cache_read_input_tokens == 768
+    assert gemini.cache_creation_input_tokens is None
 
 
 def test_extract_usage_details_gemini_modality_details():

--- a/docs/token_usage_report.md
+++ b/docs/token_usage_report.md
@@ -11,6 +11,10 @@
   - `usage.input_tokens`、`usage.output_tokens`、`usage.total_tokens`
   - 细分字段（可能存在）：`usage.input_tokens_details` / `usage.output_tokens_details`
     - 常见：`cached_tokens`、`audio_tokens`、`image_tokens`、`reasoning_tokens`、`tool_tokens`
+- 缓存计费：
+  - `prompt_tokens/input_tokens` 表示全部输入。
+  - `cached_tokens` 表示缓存读取 token。
+  - 未缓存输入需自行计算：`input_tokens - cached_tokens`。
 - 多模态：
   - 文本：由模型 tokenizer 计数（tiktoken）。
   - 图片：低清细节通常为固定 Token，高细节按 512px tile 计数。
@@ -21,6 +25,10 @@
 - Messages API:
   - `usage.input_tokens`、`usage.output_tokens`
   - 缓存相关：`cache_creation_input_tokens`、`cache_read_input_tokens`
+- 缓存计费：
+  - 原始 `usage.input_tokens` 表示未缓存输入，不是全部输入。
+  - 全部输入需统一计算：`input_tokens + cache_creation_input_tokens + cache_read_input_tokens`。
+  - `cache_creation_input_tokens` 使用缓存写入价，`cache_read_input_tokens` 使用缓存读取价。
 - 多模态：
   - 图片信息计入 input/output tokens；usage 可能仅反映总量与缓存差异。
 
@@ -29,6 +37,11 @@
   - `promptTokenCount`、`candidatesTokenCount`、`totalTokenCount`
   - `cachedContentTokenCount`
 - 多模态 token 已统一计入 prompt/candidates 的统计。
+- 缓存计费：
+  - `promptTokenCount` 表示全部输入。
+  - `cachedContentTokenCount` 表示缓存读取 token。
+  - 未缓存输入需自行计算：`promptTokenCount - cachedContentTokenCount`。
+  - Explicit Cache 的存储费用是独立资源费用，当前日志 usage 仅记录推理响应中的 token 用量。
 
 ### 1.4 OpenRouter（兼容 OpenAI）
 - 一般复用 OpenAI usage 字段：
@@ -66,6 +79,9 @@
 - `source=upstream`：响应包含 usage，且使用该数值。
 - `source=estimated`：响应缺少 usage，使用本地估算。
 - `source=mixed`：部分字段缺失，混合使用响应与本地估算。
+- `input_tokens`：统一表示全部 Prompt/Input token；Anthropic 会由三段输入相加得到。
+- `cache_read_input_tokens`：缓存读取 token；OpenAI/Gemini 从各自缓存命中字段映射而来。
+- `cache_creation_input_tokens`：缓存写入 token；主要来自 Anthropic，Gemini 显式缓存创建接口不一定出现在推理响应 usage 中。
 - `raw_usage`：原始 usage 字段（尽可能完整保留）。
 - `extra_usage`：非标准字段保留，避免丢失。
 
@@ -103,7 +119,32 @@
    - 若不包含 usage：用本地估算填充 output tokens，并保留 input tokens。
 3. **日志记录**：始终记录 `usage_details`，保留 raw usage 字段以便后续分析。
 
-## 5. 风险与改进方向
+## 5. 统一计费公式
+
+响应 usage 会先归一化为：
+
+```text
+promptTokens = input_tokens
+completionTokens = output_tokens
+cacheReadTokens = cache_read_input_tokens
+cacheWriteTokens = cache_creation_input_tokens
+regularInputTokens = max(input_tokens - cacheReadTokens - cacheWriteTokens, 0)
+```
+
+统一成本公式：
+
+```text
+Cost =
+  cacheWriteTokens * CacheWritePrice
+  + cacheReadTokens * CacheReadPrice
+  + regularInputTokens * InputPrice
+  + completionTokens * OutputPrice
+```
+
+`cached_input_cost` 当前记录缓存读取与缓存写入的合计成本，以保持日志表结构兼容。
+
+## 6. 风险与改进方向
 
 - 多模态 token 估算依赖厂商规则，现阶段用于“近似”与“路由参考”。
 - 后续可接入官方 tokenizer（如 Anthropic tokenizer）或更精确的多模态成本模型。
+- Gemini Explicit Cache 的 Cache Storage Fee 尚未并入请求级 token 计费，后续需要独立资源账单模型。


### PR DESCRIPTION
## Summary

Implements bidirectional protocol conversion (OpenAI ↔ Anthropic) to support scenarios where the supplier protocol differs from the user request protocol.

## Changes

### New Features
- **`backend/app/common/protocol_conversion.py`** (404 lines): Core protocol conversion module providing:
  - `convert_request_for_supplier`: Transforms user requests from one protocol format to the supplier's expected format (supports `/v1/chat/completions` ↔ `/v1/messages`)
  - `convert_response_for_user`: Transforms non-streaming supplier responses back to the user's expected protocol format
  - `convert_stream_for_user`: Transforms SSE streaming responses between protocols, handling OpenAI `chat.completion.chunk` and Anthropic event types (`message_start`, `content_block_start`, `content_block_delta`, etc.)
  - `normalize_protocol`: Validates and normalizes protocol identifiers

### Modified
- **`backend/app/services/proxy_service.py`**: Integrated protocol conversion into the proxy pipeline, wiring request/response transformation when supplier and user protocols differ
- **`backend/pyproject.toml`** / **`backend/requirements.txt`**: Added `litellm` as a dependency (used for `AnthropicConfig` and `AnthropicExperimentalPassThroughConfig` transformations)

### Tests
- **`tests/unit/test_common/test_protocol_conversion.py`** (194 lines): Unit tests covering request/response/stream conversion in both directions
- **`tests/unit/test_proxy_service_protocol_matching.py`**: Refactored and simplified existing protocol matching tests

## Dependencies

- Requires `litellm` — added to `requirements.txt` and `pyproject.toml`

## Protocol Support Matrix

| User Protocol | Supplier Protocol | Direction | Supported |
|---|---|---|---|
| OpenAI | Anthropic | Request conversion | ✅ |
| Anthropic | OpenAI | Request conversion | ✅ |
| OpenAI | Anthropic | Response conversion | ✅ |
| Anthropic | OpenAI | Response conversion | ✅ |
| OpenAI | Anthropic | Stream conversion | ✅ |
| Anthropic | OpenAI | Stream conversion | ✅ |
| Same | Same | Pass-through | ✅ |