### PR TITLE
feat: add protocol conversion between OpenAI and Anthropic

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -134,7 +134,7 @@
         "active": "Active",
         "inactive": "Inactive"
       },
-      "detailsOff": "Details off"
+      "detailsOff": "Request details not logged"
     },
     "toasts": {
       "copied": "API Key copied to clipboard",
@@ -156,7 +156,7 @@
       "keyNameLabel": "API Key Name",
       "keyLabel": "API Key",
       "recordDetailsLabel": "Record Request Details",
-      "recordDetailsHint": "When off, request/response bodies and headers are not logged for this key; metadata such as tokens, cost and status is still recorded."
+      "recordDetailsHint": "When off, request/response bodies and headers aren't logged; tokens and cost still are."
     },
     "success": {
       "title": "API Key Created Successfully",
@@ -764,6 +764,8 @@
       "retryUnsupported": "This log cannot be retried",
       "detailExpiredTitle": "Request detail expired",
       "detailExpiredDescription": "The summary fields are still retained, but the request body, headers, response body, and other heavy detail fields were cleaned up by retention policy.",
+      "detailNotRecordedTitle": "Request details not recorded",
+      "detailNotRecordedDescription": "This API Key has detail logging disabled, so request/response bodies and headers were not saved.",
       "detailExpiredRetryUnsupported": "Request detail has expired for this log, so retry is unavailable",
       "detailExpiredPlaygroundUnsupported": "Request detail has expired for this log, so Playground is unavailable",
       "detailExpiredCurlUnsupported": "Request detail has expired for this log, so cURL export is unavailable",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -134,7 +134,7 @@
         "active": "启用",
         "inactive": "停用"
       },
-      "detailsOff": "明细已关闭"
+      "detailsOff": "未记录请求明细"
     },
     "toasts": {
       "copied": "已复制 API Key 到剪贴板",
@@ -156,7 +156,7 @@
       "keyNameLabel": "API Key 名称",
       "keyLabel": "API Key",
       "recordDetailsLabel": "记录请求明细",
-      "recordDetailsHint": "关闭后，该 Key 的请求不再记录请求/响应体和请求头；Token、费用、状态等元数据仍会记录。"
+      "recordDetailsHint": "关闭后不记录请求/响应体和请求头，仍保留 Token、费用等统计。"
     },
     "success": {
       "title": "API Key 创建成功",
@@ -764,6 +764,8 @@
       "retryUnsupported": "当前日志不支持重试",
       "detailExpiredTitle": "请求详情已过期",
       "detailExpiredDescription": "该日志的摘要信息仍然保留，但请求体、请求头、响应体等详细内容已按保留策略自动清理。",
+      "detailNotRecordedTitle": "未记录请求明细",
+      "detailNotRecordedDescription": "该 API Key 已关闭明细记录，请求/响应体和请求头未被保存。",
       "detailExpiredRetryUnsupported": "当前日志的请求详情已过期，无法重试",
       "detailExpiredPlaygroundUnsupported": "当前日志的请求详情已过期，无法打开 Playground",
       "detailExpiredCurlUnsupported": "当前日志的请求详情已过期，无法生成 cURL",

--- a/frontend/src/components/api-keys/ApiKeyList.tsx
+++ b/frontend/src/components/api-keys/ApiKeyList.tsx
@@ -169,14 +169,17 @@ export function ApiKeyList({
                 {formatUsdCompact(apiKey.monthly_cost)}
               </TableCell>
               <TableCell>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-1.5">
                   <Badge className={status.className}>
                     {apiKey.is_active ? t('list.status.active') : t('list.status.inactive')}
                   </Badge>
                   {!apiKey.record_details && (
-                    <Badge variant="outline" className="text-muted-foreground">
-                      {t('list.detailsOff')}
-                    </Badge>
+                    <span
+                      className="inline-flex text-muted-foreground"
+                      title={t('list.detailsOff')}
+                    >
+                      <EyeOff className="h-3.5 w-3.5" suppressHydrationWarning />
+                    </span>
                   )}
                 </div>
               </TableCell>

--- a/frontend/src/components/logs/LogDetail.tsx
+++ b/frontend/src/components/logs/LogDetail.tsx
@@ -577,6 +577,19 @@ export function LogDetail({ log }: LogDetailProps) {
   if (!log) return null;
 
   const detailExpired = log.detail_available === false;
+  // Whether any heavy payload (bodies/headers) is present. When an API Key has
+  // detail logging disabled, all of these are empty, so we hide the payload card
+  // and its empty request/response/header viewers entirely.
+  const hasHeaders = (headers?: Record<string, string>) =>
+    Boolean(headers && Object.keys(headers).length > 0);
+  const hasPayloadDetail = Boolean(
+    log.request_body ||
+      log.response_body ||
+      log.converted_request_body ||
+      log.upstream_response_body ||
+      hasHeaders(log.request_headers) ||
+      hasHeaders(log.response_headers),
+  );
   const retryUnsupported =
     detailExpired ||
     !log.request_path ||
@@ -937,6 +950,21 @@ export function LogDetail({ log }: LogDetailProps) {
         </Card>
       )}
 
+      {!hasPayloadDetail && !detailExpired && (
+        <Card>
+          <CardContent className="flex items-start gap-3 p-4 text-sm text-muted-foreground">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" suppressHydrationWarning />
+            <div className="space-y-1">
+              <div className="font-medium text-foreground">
+                {t("detail.detailNotRecordedTitle")}
+              </div>
+              <div>{t("detail.detailNotRecordedDescription")}</div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {hasPayloadDetail && (
       <Card>
         <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <div>
@@ -1280,6 +1308,7 @@ export function LogDetail({ log }: LogDetailProps) {
           )}
         </CardContent>
       </Card>
+      )}
 
       <Dialog open={debugDialogOpen} onOpenChange={setDebugDialogOpen}>
         <DialogContent className="h-[85vh] max-h-[85vh] w-[min(96vw,1100px)] max-w-none overflow-hidden p-0">


### PR DESCRIPTION
## Summary

Implements bidirectional protocol conversion between OpenAI and Anthropic APIs, allowing proxy requests to be forwarded to suppliers using a different protocol than the one used by the client.

## Changes

### New Features
- **`backend/app/common/protocol_conversion.py`** (404 lines): New module implementing full OpenAI ↔ Anthropic protocol conversion:
  - `convert_request_for_supplier`: Converts client request body/path from one protocol to another before forwarding to supplier
  - `convert_response_for_user`: Converts non-streaming supplier responses back to the client's expected protocol
  - `convert_stream_for_user`: Converts SSE streaming responses between protocols (including proper event sequencing for Anthropic SSE format)
  - Utility helpers for SSE encoding, finish reason mapping, and protocol normalization
  - Uses `litellm` for underlying transformation logic

### Updates
- **`backend/app/services/proxy_service.py`**: Integrated protocol conversion into the proxy service, applying request/response transformation when supplier protocol differs from client protocol
- **`backend/pyproject.toml` / `backend/requirements.txt`**: Added `litellm` as a required dependency

### Tests
- **`backend/tests/unit/test_common/test_protocol_conversion.py`** (194 lines): Unit tests covering request conversion, response conversion, streaming conversion, edge cases, and error handling
- **`backend/tests/unit/test_proxy_service_protocol_matching.py`**: Refactored/simplified existing proxy service protocol matching tests

## Dependencies

Adds `litellm` to project dependencies for protocol transformation utilities.

## Supported Conversions

| Client → Supplier | Endpoint Mapping |
|---|---|
| OpenAI → Anthropic | `/v1/chat/completions` → `/v1/messages` |
| Anthropic → OpenAI | `/v1/messages` → `/v1/chat/completions` |