### PR TITLE
feat: add protocol conversion between OpenAI and Anthropic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ POSTGRES_PASSWORD=llm_gateway_password
 # Whether API keys can be viewed/copied again in API Keys page
 # ENABLE_VIEW_API_KEYS=false
 
+# Provider health degradation (soft circuit breaker)
+# PROVIDER_HEALTH_ENABLED=true
+# PROVIDER_HEALTH_WINDOW_SECONDS=600
+# PROVIDER_HEALTH_MIN_SAMPLES=6
+# PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD=0.5
+
 # KV store backend (docker-compose default is redis)
 # KV_STORE_TYPE=redis
 # REDIS_URL=redis://redis:6379/0

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ See [docs/api.md](docs/api.md) for complete API documentation.
 | `DATABASE_URL` | sqlite+aiosqlite:///./llm_gateway.db | Database connection string |
 | `RETRY_MAX_ATTEMPTS` | 3 | Max retry attempts for 500+ errors |
 | `RETRY_DELAY_MS` | 1000 | Delay between retries (milliseconds) |
+| `PROVIDER_HEALTH_ENABLED` | true | Enable runtime provider health degradation |
+| `PROVIDER_HEALTH_WINDOW_SECONDS` | 600 | Provider health sliding-window duration |
+| `PROVIDER_HEALTH_MIN_SAMPLES` | 6 | Minimum logical provider calls before degradation |
+| `PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD` | 0.5 | Failure rate that moves a provider behind healthy candidates |
 | `HTTP_TIMEOUT` | 1800 | Upstream request timeout (seconds) |
 | `API_KEY_PREFIX` | lgw- | Prefix for generated API keys |
 | `API_KEY_LENGTH` | 32 | Length of generated API keys |

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -254,6 +254,10 @@ response = client.responses.create(
 | `DATABASE_URL` | sqlite+aiosqlite:///./llm_gateway.db | 数据库连接字符串 |
 | `RETRY_MAX_ATTEMPTS` | 3 | 500+ 错误的最大重试次数 |
 | `RETRY_DELAY_MS` | 1000 | 重试间隔（毫秒） |
+| `PROVIDER_HEALTH_ENABLED` | true | 是否启用 Provider 运行时健康降级 |
+| `PROVIDER_HEALTH_WINDOW_SECONDS` | 600 | Provider 健康统计滑动窗口（秒） |
+| `PROVIDER_HEALTH_MIN_SAMPLES` | 6 | 触发降级判断所需的最小逻辑请求数 |
+| `PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD` | 0.5 | 将 Provider 排到健康候选之后的失败率阈值 |
 | `HTTP_TIMEOUT` | 1800 | 上游请求超时（秒） |
 | `API_KEY_PREFIX` | lgw- | 生成的 API Key 前缀 |
 | `API_KEY_LENGTH` | 32 | 生成的 API Key 长度 |

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -28,6 +28,7 @@ from app.services import (
     ModelService,
     PriorityStrategy,
     ProviderService,
+    ProviderHealthTracker,
     ProxyService,
     RoundRobinStrategy,
 )
@@ -37,6 +38,7 @@ from app.services.protocol_hooks import ProtocolConversionHooks
 _round_robin_strategy = RoundRobinStrategy()
 _cost_first_strategy = CostFirstStrategy()
 _priority_strategy = PriorityStrategy()
+_provider_health_tracker = ProviderHealthTracker.from_settings(get_settings())
 
 
 async def get_db():
@@ -90,7 +92,7 @@ def get_model_service(db: DbSession) -> ModelService:
     """Get Model Service"""
     model_repo = SQLAlchemyModelRepository(db)
     provider_repo = SQLAlchemyProviderRepository(db)
-    return ModelService(model_repo, provider_repo)
+    return ModelService(model_repo, provider_repo, _provider_health_tracker)
 
 
 def get_api_key_service(db: DbSession) -> ApiKeyService:
@@ -140,6 +142,7 @@ def get_proxy_service() -> ProxyService:
         cost_first_strategy=_cost_first_strategy,
         priority_strategy=_priority_strategy,
         protocol_hooks=_build_protocol_hooks(),
+        health_tracker=_provider_health_tracker,
     )
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,6 +35,16 @@ class Settings(BaseSettings):
     # Retry interval (ms)
     RETRY_DELAY_MS: int = 1000
 
+    # Provider Health / Soft Circuit Breaker Config
+    # Degraded providers remain available but are tried after healthy providers.
+    PROVIDER_HEALTH_ENABLED: bool = True
+    # Sliding-window duration in seconds (default: 10 minutes)
+    PROVIDER_HEALTH_WINDOW_SECONDS: int = 600
+    # Minimum logical provider calls required before degradation
+    PROVIDER_HEALTH_MIN_SAMPLES: int = 6
+    # Failure rate at or above which a provider/model mapping is degraded
+    PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD: float = 0.5
+
     # HTTP Client Config
     # Request timeout (seconds)
     HTTP_TIMEOUT: int = 1800
@@ -107,6 +117,14 @@ class Settings(BaseSettings):
         if self.LOG_DETAIL_RETENTION_DAYS > self.LOG_RETENTION_DAYS:
             raise ValueError(
                 "LOG_DETAIL_RETENTION_DAYS must be less than or equal to LOG_RETENTION_DAYS"
+            )
+        if self.PROVIDER_HEALTH_WINDOW_SECONDS < 1:
+            raise ValueError("PROVIDER_HEALTH_WINDOW_SECONDS must be >= 1")
+        if self.PROVIDER_HEALTH_MIN_SAMPLES < 1:
+            raise ValueError("PROVIDER_HEALTH_MIN_SAMPLES must be >= 1")
+        if not 0 < self.PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD <= 1:
+            raise ValueError(
+                "PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD must be in (0, 1]"
             )
         return self
 

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -349,6 +349,11 @@ class ModelMappingProviderResponse(ModelMappingProvider):
     provider_protocol: Optional[str] = Field(None, description="Provider Protocol Type")
     # Provider Active Status
     provider_is_active: Optional[bool] = Field(None, description="Provider Active Status")
+    # Runtime health state from the soft circuit breaker (not persisted config)
+    health_degraded: bool = Field(False, description="Runtime health degraded")
+    health_sample_count: int = Field(0, description="Health-window sample count")
+    health_failure_count: int = Field(0, description="Health-window failure count")
+    health_failure_rate: float = Field(0.0, description="Health-window failure rate")
     # Resolved billing config for history copy/apply scenarios
     resolved_billing_mode: Optional[BillingMode] = Field(
         None, description="Resolved billing mode after applying model fallback"

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -8,6 +8,7 @@ from app.services.model_service import ModelService
 from app.services.api_key_service import ApiKeyService
 from app.services.log_service import LogService
 from app.services.retry_handler import RetryHandler
+from app.services.provider_health import ProviderHealthTracker
 from app.services.strategy import SelectionStrategy, RoundRobinStrategy, CostFirstStrategy, PriorityStrategy
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     "ApiKeyService",
     "LogService",
     "RetryHandler",
+    "ProviderHealthTracker",
     "SelectionStrategy",
     "RoundRobinStrategy",
     "CostFirstStrategy",

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -30,6 +30,7 @@ from app.common.costs import (
 from app.rules.context import RuleContext, TokenUsage
 from app.rules.engine import RuleEngine
 from app.services.retry_handler import RetryHandler
+from app.services.provider_health import ProviderHealthTracker
 from app.services.strategy import CostFirstStrategy, PriorityStrategy, RoundRobinStrategy, SelectionStrategy
 
 
@@ -44,6 +45,7 @@ class ModelService:
         self,
         model_repo: ModelRepository,
         provider_repo: ProviderRepository,
+        health_tracker: ProviderHealthTracker | None = None,
     ):
         """
         Initialize Service
@@ -54,6 +56,7 @@ class ModelService:
         """
         self.model_repo = model_repo
         self.provider_repo = provider_repo
+        self._health_tracker = health_tracker
         self._round_robin_strategy = RoundRobinStrategy()
         self._cost_first_strategy = CostFirstStrategy()
         self._priority_strategy = PriorityStrategy()
@@ -177,7 +180,7 @@ class ModelService:
             )
 
         strategy = self._get_strategy(mapping.strategy)
-        retry_handler = RetryHandler(strategy)
+        retry_handler = RetryHandler(strategy, self._health_tracker)
         ordered_candidates = await retry_handler.get_ordered_candidates(
             candidates,
             requested_model,
@@ -795,6 +798,18 @@ class ModelService:
             providers = await self.model_repo.get_provider_mappings(
                 requested_model=mapping.requested_model
             )
+            if self._health_tracker is not None and providers:
+                health_by_mapping = await self._health_tracker.get_mapping_snapshots(
+                    provider.id for provider in providers
+                )
+                for provider in providers:
+                    health = health_by_mapping.get(provider.id)
+                    if health is None:
+                        continue
+                    provider.health_degraded = health.degraded
+                    provider.health_sample_count = health.sample_count
+                    provider.health_failure_count = health.failure_count
+                    provider.health_failure_rate = health.failure_rate
             provider_count = len(providers)
             # Active provider count requires both: mapping is_active AND provider is_active
             active_provider_count = sum(

--- a/backend/app/services/provider_health.py
+++ b/backend/app/services/provider_health.py
@@ -1,0 +1,285 @@
+"""Runtime provider health tracking and soft-circuit degradation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Iterable
+
+from app.providers.base import ProviderResponse
+from app.rules.models import CandidateProvider
+
+logger = logging.getLogger(__name__)
+
+ProviderHealthKey = tuple[str, int] | tuple[str, int, str]
+
+
+class HealthOutcome(str, Enum):
+    """Whether a logical provider call contributes to health statistics."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    IGNORED = "ignored"
+
+
+@dataclass(frozen=True)
+class ProviderHealthSnapshot:
+    """Health statistics for one provider/model candidate."""
+
+    sample_count: int = 0
+    failure_count: int = 0
+    failure_rate: float = 0.0
+    degraded: bool = False
+
+
+@dataclass
+class _HealthWindow:
+    """Mutable rolling-window data with O(1) aggregate reads."""
+
+    events: deque[tuple[float, bool]]
+    failure_count: int = 0
+
+
+def provider_health_key(candidate: CandidateProvider) -> ProviderHealthKey:
+    """Use mapping identity when available so model failures stay isolated."""
+    if candidate.provider_mapping_id is not None:
+        return ("mapping", candidate.provider_mapping_id)
+    return ("provider_target", candidate.provider_id, candidate.target_model)
+
+
+def classify_provider_response(response: ProviderResponse) -> HealthOutcome:
+    """Classify an upstream result conservatively for availability tracking.
+
+    Client payload errors are ignored because they do not establish that a
+    provider is unavailable. Authentication, timeout, throttling and upstream
+    server errors do establish an availability/configuration problem.
+    """
+    if response.is_success:
+        return HealthOutcome.SUCCESS
+
+    if response.status_code in {401, 403, 408, 429} or response.status_code >= 500:
+        return HealthOutcome.FAILURE
+
+    return HealthOutcome.IGNORED
+
+
+class ProviderHealthTracker:
+    """Keep a low-volume, in-memory sliding window for provider outcomes.
+
+    The tracker intentionally stores one event per logical provider call, not
+    one event per physical retry. It is process-local; the interface can later
+    be backed by Redis if the gateway runs multiple workers or instances.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        window_seconds: int = 600,
+        min_samples: int = 6,
+        failure_rate_threshold: float = 0.5,
+        cleanup_interval_seconds: float | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be >= 1")
+        if min_samples < 1:
+            raise ValueError("min_samples must be >= 1")
+        if not 0 < failure_rate_threshold <= 1:
+            raise ValueError("failure_rate_threshold must be in (0, 1]")
+        if cleanup_interval_seconds is not None and cleanup_interval_seconds <= 0:
+            raise ValueError("cleanup_interval_seconds must be > 0")
+
+        self.enabled = enabled
+        self.window_seconds = window_seconds
+        self.min_samples = min_samples
+        self.failure_rate_threshold = failure_rate_threshold
+        self._clock = clock
+        self._windows: dict[ProviderHealthKey, _HealthWindow] = {}
+        self._known_states: dict[ProviderHealthKey, bool] = {}
+        self._cleanup_interval_seconds = (
+            cleanup_interval_seconds
+            if cleanup_interval_seconds is not None
+            else min(60.0, float(window_seconds))
+        )
+        self._next_cleanup_at = self._clock() + self._cleanup_interval_seconds
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def from_settings(cls, settings) -> "ProviderHealthTracker":
+        return cls(
+            enabled=settings.PROVIDER_HEALTH_ENABLED,
+            window_seconds=settings.PROVIDER_HEALTH_WINDOW_SECONDS,
+            min_samples=settings.PROVIDER_HEALTH_MIN_SAMPLES,
+            failure_rate_threshold=settings.PROVIDER_HEALTH_FAILURE_RATE_THRESHOLD,
+        )
+
+    def _prune(self, key: ProviderHealthKey, now: float) -> bool:
+        window = self._windows.get(key)
+        if window is None:
+            return False
+        cutoff = now - self.window_seconds
+        while window.events and window.events[0][0] <= cutoff:
+            _, failed = window.events.popleft()
+            if failed:
+                window.failure_count -= 1
+        if not window.events:
+            self._windows.pop(key, None)
+            return True
+        return False
+
+    def _cleanup_expired(self, now: float) -> None:
+        """Periodically prune every key, including removed/inactive mappings."""
+        if now < self._next_cleanup_at:
+            return
+
+        for key in list(self._windows):
+            removed = self._prune(key, now)
+            if removed:
+                self._known_states.pop(key, None)
+
+        # A healthy/unknown key can be known without having window events.
+        # Keeping it offers no value and would retain deleted mapping IDs.
+        live_keys = self._windows.keys()
+        for key in list(self._known_states):
+            if key not in live_keys:
+                self._known_states.pop(key, None)
+
+        self._next_cleanup_at = now + self._cleanup_interval_seconds
+
+    def _snapshot(self, key: ProviderHealthKey) -> ProviderHealthSnapshot:
+        window = self._windows.get(key)
+        if window is None:
+            return ProviderHealthSnapshot()
+
+        sample_count = len(window.events)
+        failure_count = window.failure_count
+        failure_rate = failure_count / sample_count
+        degraded = (
+            sample_count >= self.min_samples
+            and failure_rate >= self.failure_rate_threshold
+        )
+        return ProviderHealthSnapshot(
+            sample_count=sample_count,
+            failure_count=failure_count,
+            failure_rate=failure_rate,
+            degraded=degraded,
+        )
+
+    def _state_transition(
+        self,
+        key: ProviderHealthKey,
+        snapshot: ProviderHealthSnapshot,
+    ) -> tuple[bool, bool] | None:
+        previous = self._known_states.get(key, False)
+        self._known_states[key] = snapshot.degraded
+        if previous == snapshot.degraded:
+            return None
+        return previous, snapshot.degraded
+
+    @staticmethod
+    def _log_transition(
+        key: ProviderHealthKey,
+        snapshot: ProviderHealthSnapshot,
+        transition: tuple[bool, bool] | None,
+    ) -> None:
+        if transition is None:
+            return
+        _, degraded = transition
+        logger.warning(
+            "Provider health state changed: key=%s state=%s samples=%s failures=%s failure_rate=%.3f",
+            key,
+            "degraded" if degraded else "healthy",
+            snapshot.sample_count,
+            snapshot.failure_count,
+            snapshot.failure_rate,
+        )
+
+    async def get_snapshots(
+        self,
+        candidates: Iterable[CandidateProvider],
+    ) -> dict[ProviderHealthKey, ProviderHealthSnapshot]:
+        keys = list(
+            dict.fromkeys(provider_health_key(candidate) for candidate in candidates)
+        )
+        return await self._get_snapshots_for_keys(keys)
+
+    async def get_mapping_snapshots(
+        self,
+        mapping_ids: Iterable[int],
+    ) -> dict[int, ProviderHealthSnapshot]:
+        """Return runtime health keyed by model-provider mapping ID."""
+        keys: list[ProviderHealthKey] = list(
+            dict.fromkeys(("mapping", mapping_id) for mapping_id in mapping_ids)
+        )
+        snapshots = await self._get_snapshots_for_keys(keys)
+        return {key[1]: snapshot for key, snapshot in snapshots.items()}
+
+    async def _get_snapshots_for_keys(
+        self,
+        keys: list[ProviderHealthKey],
+    ) -> dict[ProviderHealthKey, ProviderHealthSnapshot]:
+        if not self.enabled:
+            return {key: ProviderHealthSnapshot() for key in keys}
+
+        now = self._clock()
+        transitions: list[
+            tuple[ProviderHealthKey, ProviderHealthSnapshot, tuple[bool, bool] | None]
+        ] = []
+        async with self._lock:
+            self._cleanup_expired(now)
+            snapshots: dict[ProviderHealthKey, ProviderHealthSnapshot] = {}
+            for key in keys:
+                self._prune(key, now)
+                snapshot = self._snapshot(key)
+                snapshots[key] = snapshot
+                transitions.append((key, snapshot, self._state_transition(key, snapshot)))
+
+        for key, snapshot, transition in transitions:
+            self._log_transition(key, snapshot, transition)
+        return snapshots
+
+    async def record(
+        self,
+        candidate: CandidateProvider,
+        outcome: HealthOutcome,
+    ) -> ProviderHealthSnapshot:
+        if not self.enabled or outcome is HealthOutcome.IGNORED:
+            return ProviderHealthSnapshot()
+
+        key = provider_health_key(candidate)
+        now = self._clock()
+        async with self._lock:
+            self._cleanup_expired(now)
+            self._prune(key, now)
+            window = self._windows.get(key)
+            if window is None:
+                window = _HealthWindow(events=deque())
+                self._windows[key] = window
+            failed = outcome is HealthOutcome.FAILURE
+            window.events.append((now, failed))
+            if failed:
+                window.failure_count += 1
+            snapshot = self._snapshot(key)
+            transition = self._state_transition(key, snapshot)
+
+        self._log_transition(key, snapshot, transition)
+        return snapshot
+
+    async def record_response(
+        self,
+        candidate: CandidateProvider,
+        response: ProviderResponse,
+    ) -> ProviderHealthSnapshot:
+        return await self.record(candidate, classify_provider_response(response))
+
+    async def reset(self) -> None:
+        """Clear all runtime state. Primarily useful for tests and operations."""
+        async with self._lock:
+            self._windows.clear()
+            self._known_states.clear()
+            self._next_cleanup_at = self._clock() + self._cleanup_interval_seconds

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -41,6 +41,7 @@ from app.repositories.model_repo import ModelRepository
 from app.repositories.provider_repo import ProviderRepository
 from app.rules import CandidateProvider, RuleContext, RuleEngine, TokenUsage
 from app.services.retry_handler import AttemptRecord, RetryHandler
+from app.services.provider_health import ProviderHealthTracker
 from app.services.protocol_hooks import OPENAI_IMAGE_PATHS, ProtocolConversionHooks
 from app.services.strategy import (
     CostFirstStrategy,
@@ -147,6 +148,7 @@ class ProxyService:
         cost_first_strategy: Optional[SelectionStrategy] = None,
         priority_strategy: Optional[SelectionStrategy] = None,
         protocol_hooks: Optional[ProtocolConversionHooks] = None,
+        health_tracker: Optional[ProviderHealthTracker] = None,
     ):
         """
         Initialize Service
@@ -194,6 +196,7 @@ class ProxyService:
         self._cost_first_strategy = cost_first_strategy or CostFirstStrategy()
         self._priority_strategy = priority_strategy or PriorityStrategy()
         self._protocol_hooks = protocol_hooks or ProtocolConversionHooks()
+        self._health_tracker = health_tracker
 
     @asynccontextmanager
     async def _repos(self):
@@ -612,7 +615,7 @@ class ProxyService:
 
         # Select strategy based on model configuration
         strategy = self._get_strategy(model_mapping.strategy)
-        retry_handler = RetryHandler(strategy)
+        retry_handler = RetryHandler(strategy, self._health_tracker)
 
         failed_attempt_logged = False
         # Track protocol conversion data for logging
@@ -1170,7 +1173,7 @@ class ProxyService:
 
         # Select strategy based on model configuration
         strategy = self._get_strategy(model_mapping.strategy)
-        retry_handler = RetryHandler(strategy)
+        retry_handler = RetryHandler(strategy, self._health_tracker)
 
         # Track protocol conversion data for logging
         stream_conversion_data: dict[str, Any] = {

--- a/backend/app/services/retry_handler.py
+++ b/backend/app/services/retry_handler.py
@@ -8,12 +8,16 @@ import asyncio
 import logging
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Awaitable
+from typing import Any, AsyncIterator, Callable, Optional, Awaitable
 
 from app.config import get_settings
 from app.common.time import utc_now
 from app.providers.base import ProviderResponse
 from app.rules.models import CandidateProvider
+from app.services.provider_health import (
+    ProviderHealthTracker,
+    provider_health_key,
+)
 from app.services.strategy import SelectionStrategy
 
 logger = logging.getLogger(__name__)
@@ -62,7 +66,11 @@ class RetryHandler:
     - All providers failed: Return the last failed response
     """
     
-    def __init__(self, strategy: SelectionStrategy):
+    def __init__(
+        self,
+        strategy: SelectionStrategy,
+        health_tracker: ProviderHealthTracker | None = None,
+    ):
         """
         Initialize Handler
         
@@ -75,6 +83,7 @@ class RetryHandler:
         self.max_retries = settings.RETRY_MAX_ATTEMPTS
         # Retry interval (ms)
         self.retry_delay_ms = settings.RETRY_DELAY_MS
+        self.health_tracker = health_tracker
 
     @staticmethod
     def _candidate_key(
@@ -97,32 +106,111 @@ class RetryHandler:
 
         This mirrors provider selection + failover ordering without making requests.
         """
-        if not candidates:
-            return []
+        return [
+            candidate
+            async for candidate in self._iter_ordered_candidates(
+                candidates,
+                requested_model,
+                input_tokens=input_tokens,
+                image_count=image_count,
+            )
+        ]
 
-        ordered: list[CandidateProvider] = []
+    async def _iter_ordered_candidates(
+        self,
+        candidates: list[CandidateProvider],
+        requested_model: str,
+        *,
+        input_tokens: Optional[int] = None,
+        image_count: Optional[int] = None,
+    ) -> AsyncIterator[CandidateProvider]:
+        """Yield candidates lazily in health-aware strategy order.
+
+        Strategy selection for a fallback group is deferred until the caller
+        actually asks for a candidate from that group. This is important for
+        stateful weighted strategies: a successful primary request must not
+        advance counters for fallback providers that were never attempted.
+        """
+        if not candidates:
+            return
+
+        groups: list[tuple[str, list[CandidateProvider]]] = []
+        if self.health_tracker is None or not self.health_tracker.enabled:
+            groups.append((requested_model, candidates))
+        else:
+            snapshots = await self.health_tracker.get_snapshots(candidates)
+            healthy: list[CandidateProvider] = []
+            degraded_groups: dict[float, list[CandidateProvider]] = {}
+            for candidate in candidates:
+                snapshot = snapshots[provider_health_key(candidate)]
+                if not snapshot.degraded:
+                    healthy.append(candidate)
+                    continue
+                degraded_groups.setdefault(snapshot.failure_rate, []).append(candidate)
+
+            if healthy:
+                groups.append((requested_model, healthy))
+            for failure_rate in sorted(degraded_groups):
+                # Isolate round-robin counters for degraded fallback groups so
+                # their distribution does not disturb the healthy pool.
+                group_model_key = f"{requested_model}::degraded::{failure_rate:.6f}"
+                groups.append((group_model_key, degraded_groups[failure_rate]))
+
+        for group_model_key, group_candidates in groups:
+            async for candidate in self._iter_strategy_candidates(
+                group_candidates,
+                group_model_key,
+                input_tokens=input_tokens,
+                image_count=image_count,
+            ):
+                yield candidate
+
+    async def _iter_strategy_candidates(
+        self,
+        candidates: list[CandidateProvider],
+        requested_model: str,
+        *,
+        input_tokens: Optional[int] = None,
+        image_count: Optional[int] = None,
+    ) -> AsyncIterator[CandidateProvider]:
+        """Lazily yield one strategy group in selection/failover order."""
+        if not candidates:
+            return
+
         tried_candidates: set[tuple[str, int] | tuple[str, int, str]] = set()
         current_provider = await self.strategy.select(candidates, requested_model, input_tokens, image_count)
         while current_provider is not None:
             current_key = self._candidate_key(current_provider)
             if current_key in tried_candidates:
                 break
-            ordered.append(current_provider)
             tried_candidates.add(current_key)
+            yield current_provider
             if len(tried_candidates) >= len(candidates):
-                break
+                return
             current_provider = await self._get_next_untried_provider(
                 candidates, tried_candidates, requested_model, current_provider, input_tokens, image_count
             )
 
-        if len(ordered) == len(candidates):
-            return ordered
-
         for candidate in candidates:
             if self._candidate_key(candidate) not in tried_candidates:
-                ordered.append(candidate)
+                yield candidate
 
-        return ordered
+    async def _record_health(
+        self,
+        provider: CandidateProvider,
+        response: ProviderResponse,
+    ) -> None:
+        if self.health_tracker is None:
+            return
+        try:
+            await self.health_tracker.record_response(provider, response)
+        except Exception:
+            # Health tracking must never make the proxy request fail.
+            logger.exception(
+                "Failed to update provider health: provider_id=%s target_model=%s",
+                provider.provider_id,
+                provider.target_model,
+            )
     
     async def execute_with_retry(
         self,
@@ -158,21 +246,20 @@ class RetryHandler:
                 attempts=[],
             )
         
-        # Track tried candidates
-        tried_candidates: set[tuple[str, int] | tuple[str, int, str]] = set()
         total_retry_count = 0
         last_response: Optional[ProviderResponse] = None
         last_provider: Optional[CandidateProvider] = None
         attempts: list[AttemptRecord] = []
         attempt_index = 0
         
-        # Select the first provider
-        current_provider = await self.strategy.select(candidates, requested_model, input_tokens, image_count)
-        
-        while current_provider is not None:
-            # Record current provider as tried
-            tried_candidates.add(self._candidate_key(current_provider))
+        async for current_provider in self._iter_ordered_candidates(
+            candidates,
+            requested_model,
+            input_tokens=input_tokens,
+            image_count=image_count,
+        ):
             last_provider = current_provider
+            provider_response: Optional[ProviderResponse] = None
             
             # Same provider retry count
             same_provider_retries = 0
@@ -182,6 +269,7 @@ class RetryHandler:
                 attempt_time = utc_now()
                 response = await forward_fn(current_provider)
                 last_response = response
+                provider_response = response
                 attempt_record = AttemptRecord(
                     provider=current_provider,
                     response=response,
@@ -193,6 +281,7 @@ class RetryHandler:
 
                 # Success response
                 if response.is_success:
+                    await self._record_health(current_provider, response)
                     return RetryResult(
                         response=response,
                         retry_count=total_retry_count,
@@ -251,17 +340,9 @@ class RetryHandler:
                     )
                     total_retry_count += 1
                     break
-            
-            # Try to switch to the next provider
-            next_provider = await self._get_next_untried_provider(
-                candidates, tried_candidates, requested_model, current_provider, input_tokens, image_count
-            )
 
-            if next_provider is None:
-                # All providers tried
-                break
-
-            current_provider = next_provider
+            if provider_response is not None:
+                await self._record_health(current_provider, provider_response)
 
         # All providers failed
         return RetryResult(
@@ -304,20 +385,21 @@ class RetryHandler:
             ), None, 0
             return
             
-        tried_candidates: set[tuple[str, int] | tuple[str, int, str]] = set()
         total_retry_count = 0
         last_chunk: bytes = b""
         last_response: Optional[ProviderResponse] = None
         last_provider: Optional[CandidateProvider] = None
         attempt_index = 0
 
-        current_provider = await self.strategy.select(candidates, requested_model, input_tokens, image_count)
-
-        while current_provider is not None:
-            tried_candidates.add(self._candidate_key(current_provider))
+        async for current_provider in self._iter_ordered_candidates(
+            candidates,
+            requested_model,
+            input_tokens=input_tokens,
+            image_count=image_count,
+        ):
             last_provider = current_provider
             same_provider_retries = 0
-            pending_attempt_record: Optional[AttemptRecord] = None
+            provider_response: Optional[ProviderResponse] = None
             
             while same_provider_retries < self.max_retries:
                 try:
@@ -332,6 +414,7 @@ class RetryHandler:
                     # Get first chunk
                     chunk, response = await anext(generator)
                     last_response = response
+                    provider_response = response
                     last_chunk = chunk
                     attempt_record = AttemptRecord(
                         provider=current_provider,
@@ -344,8 +427,12 @@ class RetryHandler:
                     if response.is_success:
                         # Success, yield subsequent data
                         yield chunk, response, current_provider, total_retry_count
-                        async for chunk, response in generator:
-                            yield chunk, response, current_provider, total_retry_count
+                        final_response = response
+                        async for chunk, stream_response in generator:
+                            final_response = stream_response
+                            last_response = stream_response
+                            yield chunk, stream_response, current_provider, total_retry_count
+                        await self._record_health(current_provider, final_response)
                         return
 
                     if on_failure_attempt is not None:
@@ -384,7 +471,6 @@ class RetryHandler:
                                 current_provider.provider_id,
                                 current_provider.provider_name,
                             )
-                            pending_attempt_record = attempt_record
                             break
                     else:
                         logger.warning(
@@ -394,7 +480,6 @@ class RetryHandler:
                             response.status_code,
                         )
                         total_retry_count += 1
-                        pending_attempt_record = attempt_record
                         break
 
                 except Exception as e:
@@ -406,6 +491,8 @@ class RetryHandler:
                         request_time=attempt_time,
                         attempt_index=attempt_index,
                     )
+                    last_response = attempt_record.response
+                    provider_response = attempt_record.response
                     attempt_index += 1
                     if on_failure_attempt is not None:
                         try:
@@ -437,15 +524,10 @@ class RetryHandler:
                             current_provider.provider_id,
                             current_provider.provider_name,
                         )
-                        pending_attempt_record = attempt_record
                         break
-            
-            next_provider = await self._get_next_untried_provider(
-                candidates, tried_candidates, requested_model, current_provider, input_tokens, image_count
-            )
-            if next_provider is None:
-                break
-            current_provider = next_provider
+
+            if provider_response is not None:
+                await self._record_health(current_provider, provider_response)
             
         # All failed, return last error
         yield last_chunk, last_response or ProviderResponse(

--- a/backend/tests/unit/test_services/test_model_service_provider_mapping.py
+++ b/backend/tests/unit/test_services/test_model_service_provider_mapping.py
@@ -10,9 +10,11 @@ from app.domain.model import (
     ModelProviderBulkUpgradeRequest,
 )
 from app.domain.provider import ProviderCreate
+from app.rules.models import CandidateProvider
 from app.repositories.sqlalchemy.model_repo import SQLAlchemyModelRepository
 from app.repositories.sqlalchemy.provider_repo import SQLAlchemyProviderRepository
 from app.services.model_service import ModelService
+from app.services.provider_health import HealthOutcome, ProviderHealthTracker
 
 
 @pytest.mark.asyncio
@@ -90,6 +92,55 @@ async def test_get_mapping_includes_provider_active_status(db_session):
     assert mapping.providers is not None
     assert len(mapping.providers) == 1
     assert mapping.providers[0].provider_is_active is False
+
+
+@pytest.mark.asyncio
+async def test_get_mapping_includes_runtime_provider_health(db_session):
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    health_tracker = ProviderHealthTracker(
+        min_samples=2,
+        failure_rate_threshold=0.5,
+    )
+    service = ModelService(model_repo, provider_repo, health_tracker)
+
+    await model_repo.create_mapping(ModelMappingCreate(requested_model="health-model"))
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="health-provider",
+            base_url="https://example.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+    created = await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="health-model",
+            provider_id=provider.id,
+            target_model_name="upstream-health-model",
+            input_price=0.0,
+            output_price=0.0,
+        )
+    )
+    candidate = CandidateProvider(
+        provider_mapping_id=created.id,
+        provider_id=provider.id,
+        provider_name=provider.name,
+        base_url=provider.base_url,
+        protocol=provider.protocol,
+        api_key=provider.api_key,
+        target_model=created.target_model_name,
+    )
+    await health_tracker.record(candidate, HealthOutcome.FAILURE)
+    await health_tracker.record(candidate, HealthOutcome.SUCCESS)
+
+    mapping = await service.get_mapping("health-model")
+
+    assert mapping.providers is not None
+    assert mapping.providers[0].health_degraded is True
+    assert mapping.providers[0].health_sample_count == 2
+    assert mapping.providers[0].health_failure_count == 1
+    assert mapping.providers[0].health_failure_rate == 0.5
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_services/test_provider_health.py
+++ b/backend/tests/unit/test_services/test_provider_health.py
@@ -1,0 +1,276 @@
+import pytest
+
+from app.providers.base import ProviderResponse
+from app.rules.models import CandidateProvider
+from app.services.provider_health import (
+    HealthOutcome,
+    ProviderHealthTracker,
+    classify_provider_response,
+    provider_health_key,
+)
+from app.services.retry_handler import RetryHandler
+from app.services.strategy import CostFirstStrategy, PriorityStrategy, RoundRobinStrategy
+
+
+class MutableClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def make_candidate(
+    mapping_id: int,
+    *,
+    priority: int = 0,
+    weight: int = 1,
+    input_price: float = 1.0,
+) -> CandidateProvider:
+    return CandidateProvider(
+        provider_mapping_id=mapping_id,
+        provider_id=mapping_id,
+        provider_name=f"provider-{mapping_id}",
+        base_url=f"https://provider-{mapping_id}.example.com",
+        protocol="openai",
+        api_key="key",
+        target_model=f"model-{mapping_id}",
+        priority=priority,
+        weight=weight,
+        billing_mode="token_flat",
+        input_price=input_price,
+        output_price=input_price,
+    )
+
+
+@pytest.mark.asyncio
+async def test_degrades_only_after_minimum_samples_and_expires() -> None:
+    clock = MutableClock()
+    tracker = ProviderHealthTracker(
+        window_seconds=600,
+        min_samples=6,
+        failure_rate_threshold=0.5,
+        clock=clock,
+    )
+    candidate = make_candidate(1)
+
+    for _ in range(5):
+        await tracker.record(candidate, HealthOutcome.FAILURE)
+
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert snapshot.sample_count == 5
+    assert snapshot.failure_rate == 1.0
+    assert snapshot.degraded is False
+
+    await tracker.record(candidate, HealthOutcome.FAILURE)
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert snapshot.sample_count == 6
+    assert snapshot.degraded is True
+
+    clock.now = 600
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert snapshot.sample_count == 0
+    assert snapshot.degraded is False
+
+
+@pytest.mark.asyncio
+async def test_expiration_updates_incremental_failure_count() -> None:
+    clock = MutableClock()
+    tracker = ProviderHealthTracker(
+        window_seconds=600,
+        min_samples=1,
+        failure_rate_threshold=0.5,
+        clock=clock,
+    )
+    candidate = make_candidate(1)
+
+    await tracker.record(candidate, HealthOutcome.FAILURE)
+    clock.now = 100
+    await tracker.record(candidate, HealthOutcome.FAILURE)
+    clock.now = 200
+    await tracker.record(candidate, HealthOutcome.SUCCESS)
+
+    clock.now = 601
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert snapshot.sample_count == 2
+    assert snapshot.failure_count == 1
+    assert snapshot.failure_rate == 0.5
+
+
+@pytest.mark.asyncio
+async def test_periodic_cleanup_removes_inactive_mapping_history() -> None:
+    clock = MutableClock()
+    tracker = ProviderHealthTracker(
+        window_seconds=600,
+        min_samples=1,
+        failure_rate_threshold=0.5,
+        cleanup_interval_seconds=60,
+        clock=clock,
+    )
+    inactive = make_candidate(1)
+    active = make_candidate(2)
+    inactive_key = provider_health_key(inactive)
+
+    await tracker.record(inactive, HealthOutcome.FAILURE)
+    assert inactive_key in tracker._windows
+    assert inactive_key in tracker._known_states
+
+    # The inactive mapping is no longer queried. Activity on another mapping
+    # still triggers global cleanup after the original window has expired.
+    clock.now = 601
+    await tracker.get_snapshots([active])
+
+    assert inactive_key not in tracker._windows
+    assert inactive_key not in tracker._known_states
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [RoundRobinStrategy(), PriorityStrategy(), CostFirstStrategy()],
+)
+@pytest.mark.asyncio
+async def test_health_order_precedes_each_base_strategy(strategy) -> None:
+    tracker = ProviderHealthTracker(min_samples=2, failure_rate_threshold=0.5)
+    # The least healthy provider is intentionally most attractive by priority/cost.
+    healthy = make_candidate(1, priority=100, input_price=100.0)
+    degraded_50 = make_candidate(2, priority=10, input_price=10.0)
+    degraded_100 = make_candidate(3, priority=0, input_price=1.0)
+
+    await tracker.record(healthy, HealthOutcome.SUCCESS)
+    await tracker.record(healthy, HealthOutcome.SUCCESS)
+    await tracker.record(degraded_50, HealthOutcome.SUCCESS)
+    await tracker.record(degraded_50, HealthOutcome.FAILURE)
+    await tracker.record(degraded_100, HealthOutcome.FAILURE)
+    await tracker.record(degraded_100, HealthOutcome.FAILURE)
+
+    handler = RetryHandler(strategy, tracker)
+    ordered = await handler.get_ordered_candidates(
+        [degraded_100, degraded_50, healthy],
+        "requested-model",
+        input_tokens=1000,
+    )
+
+    assert [candidate.provider_mapping_id for candidate in ordered] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_retry_records_one_logical_sample_per_provider() -> None:
+    tracker = ProviderHealthTracker(min_samples=1, failure_rate_threshold=0.5)
+    candidate = make_candidate(1)
+    handler = RetryHandler(RoundRobinStrategy(), tracker)
+    handler.max_retries = 3
+    handler.retry_delay_ms = 0
+    calls = 0
+
+    async def forward_fn(_candidate):
+        nonlocal calls
+        calls += 1
+        return ProviderResponse(status_code=500, error="upstream failed")
+
+    result = await handler.execute_with_retry(
+        [candidate],
+        "requested-model",
+        forward_fn,
+    )
+
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert result.success is False
+    assert calls == 3
+    assert snapshot.sample_count == 1
+    assert snapshot.failure_count == 1
+
+
+@pytest.mark.asyncio
+async def test_success_after_retry_is_one_success_sample() -> None:
+    tracker = ProviderHealthTracker(min_samples=1, failure_rate_threshold=0.5)
+    candidate = make_candidate(1)
+    handler = RetryHandler(RoundRobinStrategy(), tracker)
+    handler.max_retries = 3
+    handler.retry_delay_ms = 0
+    calls = 0
+
+    async def forward_fn(_candidate):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            return ProviderResponse(status_code=500, error="temporary failure")
+        return ProviderResponse(status_code=200, body={"ok": True})
+
+    result = await handler.execute_with_retry(
+        [candidate],
+        "requested-model",
+        forward_fn,
+    )
+
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert result.success is True
+    assert snapshot.sample_count == 1
+    assert snapshot.failure_count == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_records_result_after_stream_finishes() -> None:
+    tracker = ProviderHealthTracker(min_samples=1, failure_rate_threshold=0.5)
+    candidate = make_candidate(1)
+    handler = RetryHandler(RoundRobinStrategy(), tracker)
+
+    def forward_stream_fn(_candidate):
+        async def stream():
+            response = ProviderResponse(status_code=200)
+            yield b"first", response
+            response.status_code = 502
+            response.error = "upstream disconnected"
+            yield b"error", response
+
+        return stream()
+
+    chunks = [
+        item
+        async for item in handler.execute_with_retry_stream(
+            [candidate],
+            "requested-model",
+            forward_stream_fn,
+        )
+    ]
+
+    snapshot = (await tracker.get_snapshots([candidate]))[
+        provider_health_key(candidate)
+    ]
+    assert [chunk for chunk, *_ in chunks] == [b"first", b"error"]
+    assert snapshot.sample_count == 1
+    assert snapshot.failure_count == 1
+
+
+def test_response_classification_is_conservative() -> None:
+    assert (
+        classify_provider_response(ProviderResponse(status_code=200))
+        is HealthOutcome.SUCCESS
+    )
+    assert (
+        classify_provider_response(ProviderResponse(status_code=429))
+        is HealthOutcome.FAILURE
+    )
+    assert (
+        classify_provider_response(ProviderResponse(status_code=503))
+        is HealthOutcome.FAILURE
+    )
+    assert (
+        classify_provider_response(ProviderResponse(status_code=400))
+        is HealthOutcome.IGNORED
+    )
+    assert (
+        classify_provider_response(ProviderResponse(status_code=404))
+        is HealthOutcome.IGNORED
+    )

--- a/backend/tests/unit/test_services/test_retry_handler.py
+++ b/backend/tests/unit/test_services/test_retry_handler.py
@@ -5,7 +5,7 @@ Retry Handler Unit Tests
 import pytest
 from unittest.mock import AsyncMock
 from app.services.retry_handler import RetryHandler
-from app.services.strategy import RoundRobinStrategy
+from app.services.strategy import PriorityStrategy, RoundRobinStrategy
 from app.providers.base import ProviderResponse
 from app.rules.models import CandidateProvider
 
@@ -202,3 +202,106 @@ class TestRetryHandler:
         assert result.success is True
         assert result.final_provider.provider_mapping_id == 202
         assert called_models == ["model-a", "model-b"]
+
+
+def _priority_fallback_candidates() -> list[CandidateProvider]:
+    return [
+        CandidateProvider(
+            provider_mapping_id=301,
+            provider_id=1,
+            provider_name="Primary",
+            base_url="https://primary.example.com",
+            protocol="openai",
+            api_key="key1",
+            target_model="primary-model",
+            priority=0,
+            weight=1,
+        ),
+        CandidateProvider(
+            provider_mapping_id=302,
+            provider_id=2,
+            provider_name="FallbackA",
+            base_url="https://fallback-a.example.com",
+            protocol="openai",
+            api_key="key2",
+            target_model="fallback-a-model",
+            priority=1,
+            weight=1,
+        ),
+        CandidateProvider(
+            provider_mapping_id=303,
+            provider_id=3,
+            provider_name="FallbackB",
+            base_url="https://fallback-b.example.com",
+            protocol="openai",
+            api_key="key3",
+            target_model="fallback-b-model",
+            priority=1,
+            weight=3,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unattempted_priority_fallback_does_not_advance_weight_counter():
+    handler = RetryHandler(PriorityStrategy())
+    candidates = _priority_fallback_candidates()
+    fallback_provider_ids: list[int] = []
+
+    for request_number in range(1, 9):
+        async def forward_fn(candidate, current_request=request_number):
+            if candidate.priority == 0:
+                if current_request % 4 == 0:
+                    return ProviderResponse(status_code=400, error="primary failed")
+                return ProviderResponse(status_code=200, body={"ok": True})
+
+            fallback_provider_ids.append(candidate.provider_id)
+            return ProviderResponse(status_code=200, body={"ok": True})
+
+        result = await handler.execute_with_retry(
+            candidates,
+            "test-model",
+            forward_fn,
+        )
+        assert result.success is True
+
+    # The 1:3 fallback group was reached only twice, so its first two actual
+    # selections must be A then B. Successful primary requests do not count.
+    assert fallback_provider_ids == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_unattempted_stream_fallback_does_not_advance_weight_counter():
+    handler = RetryHandler(PriorityStrategy())
+    candidates = _priority_fallback_candidates()
+    fallback_provider_ids: list[int] = []
+
+    for request_number in range(1, 9):
+        def forward_stream_fn(candidate, current_request=request_number):
+            async def stream():
+                if candidate.priority == 0:
+                    if current_request % 4 == 0:
+                        yield b"", ProviderResponse(
+                            status_code=400,
+                            error="primary failed",
+                        )
+                        return
+                    yield b"ok", ProviderResponse(status_code=200)
+                    return
+
+                fallback_provider_ids.append(candidate.provider_id)
+                yield b"ok", ProviderResponse(status_code=200)
+
+            return stream()
+
+        chunks = [
+            item
+            async for item in handler.execute_with_retry_stream(
+                candidates,
+                "test-model",
+                forward_stream_fn,
+            )
+        ]
+        assert chunks[-1][1].is_success is True
+
+    assert fallback_provider_ids == [2, 3]

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -450,6 +450,8 @@
       "protocolTitle": "Protocol: {protocol}",
       "configured": "Configured",
       "providerDisabledTooltip": "The provider for this model is currently disabled",
+      "healthDegraded": "Degraded",
+      "healthDegradedTooltip": "The current health window contains {samples} requests and {failures} failures ({failureRate}). This provider remains available as a fallback.",
       "priorityPromoted": "Promoted this model to top priority and reordered priorities",
       "priorityPromoteFailed": "Failed to update priorities",
       "noProviders": "No providers configured, click button above to add",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -450,6 +450,8 @@
       "protocolTitle": "协议：{protocol}",
       "configured": "已配置",
       "providerDisabledTooltip": "当前模型的供应商已禁用",
+      "healthDegraded": "已降级",
+      "healthDegradedTooltip": "当前健康窗口共 {samples} 次请求，其中 {failures} 次失败，失败率 {failureRate}。该供应商仍会作为后备候选。",
       "priorityPromoted": "已将该模型设为最高优先级并重新排序",
       "priorityPromoteFailed": "更新优先级失败",
       "noProviders": "未配置供应商，点击上方按钮添加",

--- a/frontend/src/app/models/detail/page.tsx
+++ b/frontend/src/app/models/detail/page.tsx
@@ -27,7 +27,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ArrowLeft, ChevronsUp, Loader2, Plus, Pencil, Trash2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  ChevronsUp,
+  Loader2,
+  Plus,
+  Pencil,
+  Trash2,
+  TriangleAlert,
+} from 'lucide-react';
 import {
   BillingDisplay,
   ModelProviderForm,
@@ -98,7 +106,9 @@ function ModelDetailContent() {
   const [deletingMapping, setDeletingMapping] = useState<ModelMappingProvider | null>(null);
   const [prioritizingMappingId, setPrioritizingMappingId] = useState<number | null>(null);
 
-  const { data: model, isLoading, isError, refetch } = useModel(requestedModel);
+  const { data: model, isLoading, isError, refetch } = useModel(requestedModel, {
+    refetchInterval: 30 * 1000,
+  });
   const { data: modelStatsData } = useModelStats({ requested_model: requestedModel });
   const { data: providerStatsData } = useModelProviderStats({ requested_model: requestedModel });
   const { data: providerNames = [] } = useProviderNames();
@@ -431,10 +441,21 @@ function ModelDetailContent() {
                   const protocol =
                     mapping.provider_protocol ??
                     providersById.get(mapping.provider_id)?.protocol;
+                  const healthFailureRate = formatRate(mapping.health_failure_rate);
+                  const healthTooltip = mapping.health_degraded
+                    ? t('detail.healthDegradedTooltip', {
+                        samples: mapping.health_sample_count ?? 0,
+                        failures: mapping.health_failure_count ?? 0,
+                        failureRate: healthFailureRate,
+                      })
+                    : undefined;
                   return (
-                    <TableRow key={mapping.id}>
+                    <TableRow
+                      key={mapping.id}
+                      className={mapping.health_degraded ? 'bg-amber-500/[0.04]' : undefined}
+                    >
                       <TableCell className="font-medium">
-                        <div className="flex items-center gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
                           <span>{mapping.provider_name}</span>
                           {protocol ? (
                             <Badge
@@ -444,6 +465,33 @@ function ModelDetailContent() {
                             >
                               {protocolLabel(protocol, protocolConfigs)}
                             </Badge>
+                          ) : null}
+                          {mapping.health_degraded ? (
+                            <TooltipProvider delayDuration={200}>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Badge
+                                    variant="warning"
+                                    className="gap-1 whitespace-nowrap font-medium"
+                                    tabIndex={0}
+                                    aria-label={healthTooltip}
+                                  >
+                                    <TriangleAlert
+                                      className="h-3 w-3"
+                                      aria-hidden="true"
+                                      suppressHydrationWarning
+                                    />
+                                    {t('detail.healthDegraded')}
+                                    <span className="font-mono tabular-nums">
+                                      {healthFailureRate}
+                                    </span>
+                                  </Badge>
+                                </TooltipTrigger>
+                                <TooltipContent className="max-w-72 text-xs leading-relaxed">
+                                  {healthTooltip}
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
                           ) : null}
                         </div>
                       </TableCell>

--- a/frontend/src/lib/hooks/useModels.ts
+++ b/frontend/src/lib/hooks/useModels.ts
@@ -67,11 +67,15 @@ export function useModels(params?: ModelListParams) {
 /**
  * Get Single Model Mapping Detail Hook (Includes Provider Config)
  */
-export function useModel(requestedModel: string) {
+export function useModel(
+  requestedModel: string,
+  options?: { refetchInterval?: number | false }
+) {
   return useQuery({
     queryKey: QUERY_KEYS.modelDetail(requestedModel),
     queryFn: () => getModel(requestedModel),
     enabled: !!requestedModel, // Only query when requestedModel is valid
+    refetchInterval: options?.refetchInterval,
   });
 }
 

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -52,6 +52,10 @@ export interface ModelMappingProvider {
   provider_name: string;              // Obtained via join
   provider_protocol?: ProtocolType | null; // Obtained via join
   provider_is_active?: boolean | null; // Obtained via join
+  health_degraded?: boolean;           // Runtime soft-circuit state
+  health_sample_count?: number;
+  health_failure_count?: number;
+  health_failure_rate?: number;
   resolved_billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | 'inherit_model_default' | null;
   resolved_input_price?: number | null;
   resolved_output_price?: number | null;


### PR DESCRIPTION
## Summary

Implements bidirectional protocol conversion between OpenAI and Anthropic APIs, allowing proxy requests to be forwarded to suppliers using a different protocol than the one used by the client.

## Changes

### New Features
- **`backend/app/common/protocol_conversion.py`** – Core protocol conversion module with:
  - `convert_request_for_supplier()`: Transforms request body and path from client protocol to supplier protocol (OpenAI ↔ Anthropic)
  - `convert_response_for_user()`: Transforms non-streaming response body from supplier protocol back to client protocol
  - `convert_stream_for_user()`: Transforms SSE streaming responses between protocols, handling message lifecycle events (message_start, content_block_start/stop, message_delta, message_stop)
  - `normalize_protocol()`: Validates and normalizes protocol identifiers
  - Leverages `litellm`'s `AnthropicConfig` and `AnthropicExperimentalPassThroughConfig` for transformations

### Updates
- **`backend/app/services/proxy_service.py`** – Integrated protocol conversion into the proxy pipeline for both streaming and non-streaming responses
- **`backend/pyproject.toml`** / **`backend/requirements.txt`** – Added `litellm` as a dependency

### Tests
- **`test_common/test_protocol_conversion.py`** – 194-line unit test suite covering request/response conversion in both directions and passthrough behavior
- **`test_proxy_service_protocol_matching.py`** – Refactored existing protocol matching tests

## Supported Conversions

| Client Protocol | Supplier Protocol | Request Path |
|---|---|---|
| OpenAI | Anthropic | `/v1/chat/completions` → `/v1/messages` |
| Anthropic | OpenAI | `/v1/messages` → `/v1/chat/completions` |
| Same | Same | Passthrough (no conversion) |