### PR TITLE
feat: add protocol conversion between OpenAI and Anthropic

### DIFF
--- a/frontend/src/components/logs/LogList.tsx
+++ b/frontend/src/components/logs/LogList.tsx
@@ -211,15 +211,12 @@ export function LogList({ logs, onView }: LogListProps) {
                 </TableCell>
                 <TableCell>
                   <div className="flex flex-col items-start gap-1">
-                    {inProgress ? (
-                      <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-800">
-                        {t('list.processing')}
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className={statusColor}>
-                        {log.response_status ?? t('unknown')}
-                      </Badge>
-                    )}
+                    <Badge
+                      variant="outline"
+                      className={inProgress ? 'text-muted-foreground' : statusColor}
+                    >
+                      {inProgress ? '-' : (log.response_status ?? t('unknown'))}
+                    </Badge>
                     {log.retry_count > 0 && (
                       <span className="text-xs text-orange-500">
                         {t('list.retry', { count: log.retry_count })}


### PR DESCRIPTION
## Summary

Implements bidirectional protocol conversion between OpenAI and Anthropic APIs, allowing proxy requests to be served when the supplier's protocol differs from the client's requested protocol.

## Changes

### New Features
- **`backend/app/common/protocol_conversion.py`** (404 lines): New module implementing full OpenAI ↔ Anthropic protocol conversion:
  - `convert_request_for_supplier`: Transforms outgoing request bodies/paths between protocols (OpenAI `/v1/chat/completions` ↔ Anthropic `/v1/messages`)
  - `convert_response_for_user`: Transforms non-streaming responses back to the client's expected protocol
  - `convert_stream_for_user`: Transforms SSE streaming responses, including proper event sequencing (`message_start`, `content_block_start`, `content_block_delta`, `message_stop`, etc.)
  - Uses `litellm` under the hood for core transformation logic

### Modified Files
- **`backend/app/services/proxy_service.py`**: Integrated protocol conversion into the proxy pipeline for both streaming and non-streaming responses
- **`backend/pyproject.toml`** / **`backend/requirements.txt`**: Added `litellm` as a dependency

### Tests
- **`backend/tests/unit/test_common/test_protocol_conversion.py`** (194 lines): Unit tests covering request/response conversion in both directions and streaming conversion
- **`backend/tests/unit/test_proxy_service_protocol_matching.py`**: Refactored existing protocol-matching tests to align with the new conversion layer

## Dependencies
- Requires `litellm` (added to `requirements.txt`)

## Notes
- Only Chat/Messages endpoints are supported for conversion (`/v1/chat/completions` and `/v1/messages`)
- If protocols match, requests/responses are passed through unchanged
- Unsupported protocol combinations raise a `ServiceError` with code `unsupported_protocol_conversion`