### PR TITLE
refactor(logs): simplify in-progress status badge rendering

### DIFF
--- a/frontend/src/components/logs/LogList.tsx
+++ b/frontend/src/components/logs/LogList.tsx
@@ -211,15 +211,12 @@ export function LogList({ logs, onView }: LogListProps) {
                 </TableCell>
                 <TableCell>
                   <div className="flex flex-col items-start gap-1">
-                    {inProgress ? (
-                      <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-800">
-                        {t('list.processing')}
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className={statusColor}>
-                        {log.response_status ?? t('unknown')}
-                      </Badge>
-                    )}
+                    <Badge
+                      variant="outline"
+                      className={inProgress ? 'text-muted-foreground' : statusColor}
+                    >
+                      {inProgress ? '-' : (log.response_status ?? t('unknown'))}
+                    </Badge>
                     {log.retry_count > 0 && (
                       <span className="text-xs text-orange-500">
                         {t('list.retry', { count: log.retry_count })}


### PR DESCRIPTION
## Summary

Simplifies the status badge rendering logic in `LogList.tsx` by consolidating two separate conditional `Badge` components into a single unified `Badge` component.

## Changes

- **`frontend/src/components/logs/LogList.tsx`**: Replaced the ternary-based dual `Badge` rendering with a single `Badge` component that conditionally applies styles and content based on the `inProgress` state.
  - In-progress items now display a `-` placeholder with muted foreground styling instead of a dedicated blue-themed badge with a localized label.
  - Non-in-progress items continue to display the response status (or `unknown`) with the appropriate `statusColor` class.

## Motivation

Reduces code duplication and improves maintainability by unifying the badge rendering into a single element, making future style or content changes easier to apply consistently.