### PR TITLE
feat(proxy): support OpenAI/Anthropic protocol conversion

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -238,6 +238,12 @@ class ModelMappingProvider(Base):
     weight: Mapped[int] = mapped_column(Integer, default=1)
     # Is Active
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Temporary pause window end (UTC, naive). When set to a future time, this
+    # mapping is still a candidate but scheduled last (after all non-paused
+    # mappings). NULL or a past value means normally available.
+    paused_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
     # Creation Time
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=utc_now_naive, nullable=False
@@ -246,7 +252,7 @@ class ModelMappingProvider(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=utc_now_naive, onupdate=utc_now_naive, nullable=False
     )
-    
+
     # Relationships
     provider: Mapped["ServiceProvider"] = relationship(
         "ServiceProvider", back_populates="model_mappings"

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -162,6 +162,7 @@ def _run_migrations(sync_conn) -> None:
             "cached_input_price": "cached_input_price NUMERIC(12,4)",
             "cached_output_price": "cached_output_price NUMERIC(12,4)",
             "cache_creation_input_price": "cache_creation_input_price NUMERIC(12,4)",
+            "paused_until": "paused_until TIMESTAMP",
         },
     )
     ensure_columns(

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -214,6 +214,11 @@ class ModelMappingProviderCreate(ModelMappingProviderBase):
     weight: int = Field(1, ge=1, description="Weight")
     # Is Active
     is_active: bool = Field(True, description="Is Active")
+    # Temporary pause window end (UTC). Future value = temporarily paused
+    # (scheduled last); None/past = normally available.
+    paused_until: Optional[datetime] = Field(
+        None, description="Temporary pause window end (UTC)"
+    )
     # Provider override pricing (USD per 1,000,000 tokens)
     input_price: Optional[float] = Field(None, description="Input price override ($/1M tokens)")
     output_price: Optional[float] = Field(None, description="Output price override ($/1M tokens)")
@@ -261,6 +266,8 @@ class ModelMappingProviderUpdate(BaseModel):
     priority: Optional[int] = None
     weight: Optional[int] = Field(None, ge=1)
     is_active: Optional[bool] = None
+    # Temporary pause window end (UTC). Future = pause, explicit null = resume now.
+    paused_until: Optional[datetime] = None
     input_price: Optional[float] = None
     output_price: Optional[float] = None
     billing_mode: Optional[BillingMode] = None
@@ -334,6 +341,7 @@ class ModelMappingProvider(ModelMappingProviderBase):
     priority: int = 0
     weight: int = 1
     is_active: bool = True
+    paused_until: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/repositories/sqlalchemy/model_repo.py
+++ b/backend/app/repositories/sqlalchemy/model_repo.py
@@ -101,6 +101,9 @@ class SQLAlchemyModelRepository(ModelRepository):
             priority=entity.priority,
             weight=entity.weight,
             is_active=entity.is_active,
+            paused_until=ensure_utc(entity.paused_until)
+            if entity.paused_until is not None
+            else None,
             created_at=ensure_utc(entity.created_at),
             updated_at=ensure_utc(entity.updated_at),
         )
@@ -285,6 +288,9 @@ class SQLAlchemyModelRepository(ModelRepository):
             priority=data.priority,
             weight=data.weight,
             is_active=data.is_active,
+            paused_until=to_utc_naive(data.paused_until)
+            if data.paused_until is not None
+            else None,
         )
         self.session.add(entity)
         await self.session.commit()
@@ -393,13 +399,17 @@ class SQLAlchemyModelRepository(ModelRepository):
         
         update_data = data.model_dump(exclude_unset=True)
         for key, value in update_data.items():
+            # paused_until is stored as a naive UTC datetime; normalize any
+            # tz-aware input so comparisons at schedule time stay consistent.
+            if key == "paused_until" and value is not None:
+                value = to_utc_naive(value)
             setattr(entity, key, value)
-        
+
         entity.updated_at = to_utc_naive(utc_now())
-        
+
         await self.session.commit()
         await self.session.refresh(entity)
-        
+
         provider_name = entity.provider.name if entity.provider else ""
         provider_protocol = entity.provider.protocol if entity.provider else None
         return self._provider_mapping_to_domain(entity, provider_name, provider_protocol)
@@ -428,6 +438,9 @@ class SQLAlchemyModelRepository(ModelRepository):
         now = to_utc_naive(utc_now())
         for entity in entities:
             for key, value in update_data.items():
+                # Keep paused_until as naive UTC, mirroring update_provider_mapping.
+                if key == "paused_until" and value is not None:
+                    value = to_utc_naive(value)
                 setattr(entity, key, value)
             entity.updated_at = now
 

--- a/backend/app/rules/engine.py
+++ b/backend/app/rules/engine.py
@@ -96,6 +96,7 @@ class RuleEngine:
                         model_per_image_price=model_mapping.per_image_price,
                         model_tiered_pricing=model_mapping.tiered_pricing,
                         provider_mapping_id=pm.id,
+                        paused_until=pm.paused_until,
                     )
                 )
 
@@ -164,6 +165,7 @@ class RuleEngine:
                         model_per_image_price=model_mapping.per_image_price,
                         model_tiered_pricing=model_mapping.tiered_pricing,
                         provider_mapping_id=pm.id,
+                        paused_until=pm.paused_until,
                     )
                 )
 

--- a/backend/app/rules/models.py
+++ b/backend/app/rules/models.py
@@ -5,6 +5,7 @@ Defines data structures used by the rule engine.
 """
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Optional
 
 
@@ -134,3 +135,6 @@ class CandidateProvider:
     model_per_image_price: Optional[float] = None
     model_tiered_pricing: Optional[list[Any]] = None
     provider_mapping_id: Optional[int] = None
+    # Temporary pause window end (UTC). When set to a future time, this
+    # candidate is scheduled last (after all non-paused candidates).
+    paused_until: Optional[datetime] = None

--- a/backend/app/services/retry_handler.py
+++ b/backend/app/services/retry_handler.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncIterator, Callable, Optional, Awaitable
 
 from app.config import get_settings
-from app.common.time import utc_now
+from app.common.time import ensure_utc, utc_now
 from app.providers.base import ProviderResponse
 from app.rules.models import CandidateProvider
 from app.services.provider_health import (
@@ -134,14 +134,29 @@ class RetryHandler:
         if not candidates:
             return
 
+        # Split off temporarily-paused candidates: they remain eligible but are
+        # scheduled after every non-paused candidate, so a paused provider is
+        # only tried once all active providers have failed. An expired
+        # paused_until is treated as active.
+        now = utc_now()
+        active_candidates: list[CandidateProvider] = []
+        paused_candidates: list[CandidateProvider] = []
+        for candidate in candidates:
+            paused_until = candidate.paused_until
+            if paused_until is not None and ensure_utc(paused_until) > now:
+                paused_candidates.append(candidate)
+            else:
+                active_candidates.append(candidate)
+
         groups: list[tuple[str, list[CandidateProvider]]] = []
         if self.health_tracker is None or not self.health_tracker.enabled:
-            groups.append((requested_model, candidates))
+            if active_candidates:
+                groups.append((requested_model, active_candidates))
         else:
-            snapshots = await self.health_tracker.get_snapshots(candidates)
+            snapshots = await self.health_tracker.get_snapshots(active_candidates)
             healthy: list[CandidateProvider] = []
             degraded_groups: dict[float, list[CandidateProvider]] = {}
-            for candidate in candidates:
+            for candidate in active_candidates:
                 snapshot = snapshots[provider_health_key(candidate)]
                 if not snapshot.degraded:
                     healthy.append(candidate)
@@ -155,6 +170,10 @@ class RetryHandler:
                 # their distribution does not disturb the healthy pool.
                 group_model_key = f"{requested_model}::degraded::{failure_rate:.6f}"
                 groups.append((group_model_key, degraded_groups[failure_rate]))
+
+        # Paused candidates come last, in their own isolated strategy group.
+        if paused_candidates:
+            groups.append((f"{requested_model}::paused", paused_candidates))
 
         for group_model_key, group_candidates in groups:
             async for candidate in self._iter_strategy_candidates(

--- a/backend/tests/unit/test_services/test_model_service_provider_mapping.py
+++ b/backend/tests/unit/test_services/test_model_service_provider_mapping.py
@@ -365,3 +365,89 @@ async def test_get_provider_pricing_history_resolves_inherited_model_billing(db_
     assert history[0].resolved_cache_billing_enabled is True
     assert history[0].resolved_cached_input_price == 0.05
     assert history[0].resolved_cached_output_price == 0.2
+
+
+@pytest.mark.asyncio
+async def test_update_provider_mapping_pause_and_resume(db_session):
+    from datetime import timedelta
+    from app.common.time import utc_now
+
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    service = ModelService(model_repo, provider_repo)
+
+    await model_repo.create_mapping(ModelMappingCreate(requested_model="gpt-4o-mini"))
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="p1",
+            base_url="https://example.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+    created = await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="gpt-4o-mini",
+            provider_id=provider.id,
+            target_model_name="gpt-4o-mini",
+            input_price=0.0,
+            output_price=0.0,
+        )
+    )
+    assert created.paused_until is None
+
+    # Pause into the future.
+    paused_until = utc_now() + timedelta(hours=1)
+    updated = await service.update_provider_mapping(
+        created.id,
+        ModelMappingProviderUpdate(paused_until=paused_until),
+    )
+    assert updated.paused_until is not None
+    # Stored value round-trips to (approximately) the same instant.
+    assert abs((updated.paused_until - paused_until).total_seconds()) < 2
+
+    # Resume by explicitly clearing paused_until.
+    resumed = await service.update_provider_mapping(
+        created.id,
+        ModelMappingProviderUpdate(paused_until=None),
+    )
+    assert resumed.paused_until is None
+
+
+@pytest.mark.asyncio
+async def test_create_provider_mapping_persists_paused_until(db_session):
+    """A mapping created with paused_until must not silently drop it."""
+    from datetime import timedelta
+    from app.common.time import utc_now
+
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    service = ModelService(model_repo, provider_repo)
+
+    await model_repo.create_mapping(ModelMappingCreate(requested_model="gpt-4o-mini"))
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="p1",
+            base_url="https://example.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+
+    paused_until = utc_now() + timedelta(hours=1)
+    created = await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="gpt-4o-mini",
+            provider_id=provider.id,
+            target_model_name="gpt-4o-mini",
+            input_price=0.0,
+            output_price=0.0,
+            paused_until=paused_until,
+        )
+    )
+    assert created.paused_until is not None
+    assert abs((created.paused_until - paused_until).total_seconds()) < 2
+
+    # And it round-trips on read.
+    mappings = await model_repo.get_provider_mappings(requested_model="gpt-4o-mini")
+    assert mappings[0].paused_until is not None

--- a/backend/tests/unit/test_services/test_retry_handler.py
+++ b/backend/tests/unit/test_services/test_retry_handler.py
@@ -305,3 +305,105 @@ async def test_unattempted_stream_fallback_does_not_advance_weight_counter():
         assert chunks[-1][1].is_success is True
 
     assert fallback_provider_ids == [2, 3]
+
+
+def _paused_candidates(paused_until):
+    """Three candidates A, C active and B paused (paused_until)."""
+    return [
+        CandidateProvider(
+            provider_mapping_id=401,
+            provider_id=1,
+            provider_name="A",
+            base_url="https://a.example.com",
+            protocol="openai",
+            api_key="k1",
+            target_model="model-a",
+            priority=0,
+        ),
+        CandidateProvider(
+            provider_mapping_id=402,
+            provider_id=2,
+            provider_name="B-paused",
+            base_url="https://b.example.com",
+            protocol="openai",
+            api_key="k2",
+            target_model="model-b",
+            priority=1,
+            paused_until=paused_until,
+        ),
+        CandidateProvider(
+            provider_mapping_id=403,
+            provider_id=3,
+            provider_name="C",
+            base_url="https://c.example.com",
+            protocol="openai",
+            api_key="k3",
+            target_model="model-c",
+            priority=2,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_paused_candidate_scheduled_last():
+    """A candidate paused into the future is ordered after all active ones."""
+    from datetime import timedelta
+    from app.common.time import utc_now
+
+    handler = RetryHandler(PriorityStrategy())
+    candidates = _paused_candidates(utc_now() + timedelta(hours=1))
+
+    ordered = await handler.get_ordered_candidates(candidates, "test-model")
+    ids = [c.provider_mapping_id for c in ordered]
+
+    # B (402) is paused, so it must come after both active A (401) and C (403).
+    assert ids[-1] == 402
+    assert set(ids[:-1]) == {401, 403}
+
+
+@pytest.mark.asyncio
+async def test_expired_pause_is_treated_as_active():
+    """A paused_until in the past no longer deprioritizes the candidate."""
+    from datetime import timedelta
+    from app.common.time import utc_now
+
+    handler = RetryHandler(PriorityStrategy())
+    candidates = _paused_candidates(utc_now() - timedelta(hours=1))
+
+    ordered = await handler.get_ordered_candidates(candidates, "test-model")
+    ids = [c.provider_mapping_id for c in ordered]
+
+    # Expired pause => normal priority order 401, 402, 403.
+    assert ids == [401, 402, 403]
+
+
+@pytest.mark.asyncio
+async def test_paused_candidate_still_tried_when_active_fail():
+    """When every active provider fails, the paused one is used as last resort."""
+    from datetime import timedelta
+    from app.common.time import utc_now
+
+    handler = RetryHandler(PriorityStrategy())
+    handler.max_retries = 1
+    candidates = _paused_candidates(utc_now() + timedelta(hours=1))
+    tried: list[int] = []
+
+    async def forward_fn(candidate):
+        tried.append(candidate.provider_mapping_id)
+        # Active providers (A, C) fail with client error; paused B succeeds.
+        if candidate.provider_mapping_id == 402:
+            return ProviderResponse(status_code=200, body={"ok": True})
+        return ProviderResponse(status_code=400, body={"err": "bad"})
+
+    result = await handler.execute_with_retry(
+        candidates=candidates,
+        requested_model="test-model",
+        forward_fn=forward_fn,
+    )
+
+    assert result.success is True
+    assert result.final_provider.provider_mapping_id == 402
+    # Paused B is only reached after both active providers were tried.
+    assert tried[-1] == 402
+    assert set(tried[:-1]) == {401, 403}
+

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -639,6 +639,28 @@
       "importFailed": "Import failed: {message}",
       "importFailedUnknown": "Import failed due to an unknown error",
       "exportFailed": "Export failed"
+    },
+    "availability": {
+      "title": "Availability",
+      "subtitle": "{provider} · {model}",
+      "available": "Available",
+      "availableDesc": "Scheduled normally by priority and weight.",
+      "paused": "Temporarily paused",
+      "pausedDesc": "Kept as a candidate but scheduled last — only used after all other providers fail. Auto-resumes when the window ends.",
+      "disabled": "Permanently disabled",
+      "disabledDesc": "Removed from scheduling until you re-enable it.",
+      "durationLabel": "Pause duration",
+      "durationMinutes": "{minutes} min",
+      "durationHours": "{hours}h",
+      "customDuration": "Custom",
+      "customPlaceholder": "Minutes",
+      "minutesUnit": "minutes",
+      "overrideHint": "Saving will override the current pause window with the new duration.",
+      "remainingMinutes": "{minutes}m left",
+      "remainingHours": "{hours}h left",
+      "remainingHoursMinutes": "{hours}h {minutes}m left",
+      "pausedBadge": "Paused · {remaining}",
+      "pausedStatusTooltip": "Temporarily paused: other providers are scheduled first, and this one is only tried if they all fail. It resumes automatically when the window ends."
     }
   },
   "logs": {

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -639,6 +639,28 @@
       "importFailed": "导入失败：{message}",
       "importFailedUnknown": "导入失败，发生未知错误",
       "exportFailed": "导出失败"
+    },
+    "availability": {
+      "title": "可用性",
+      "subtitle": "{provider} · {model}",
+      "available": "正常可用",
+      "availableDesc": "按优先级与权重正常参与调度。",
+      "paused": "临时暂停",
+      "pausedDesc": "仍作为候选，但排到最后——仅当其他供应商全部失败后才会用到。时间窗口结束后自动恢复。",
+      "disabled": "永久停用",
+      "disabledDesc": "在重新启用之前，不参与调度。",
+      "durationLabel": "暂停时长",
+      "durationMinutes": "{minutes} 分钟",
+      "durationHours": "{hours} 小时",
+      "customDuration": "自定义",
+      "customPlaceholder": "分钟数",
+      "minutesUnit": "分钟",
+      "overrideHint": "保存后将以新的时长覆盖当前的暂停窗口。",
+      "remainingMinutes": "剩余 {minutes} 分钟",
+      "remainingHours": "剩余 {hours} 小时",
+      "remainingHoursMinutes": "剩余 {hours} 小时 {minutes} 分钟",
+      "pausedBadge": "已暂停 · {remaining}",
+      "pausedStatusTooltip": "临时暂停中：会优先调度其他供应商，仅当它们全部失败时才会用到该供应商。窗口结束后自动恢复。"
     }
   },
   "logs": {

--- a/frontend/src/app/models/detail/page.tsx
+++ b/frontend/src/app/models/detail/page.tsx
@@ -33,6 +33,7 @@ import {
   Loader2,
   Plus,
   Pencil,
+  PauseCircle,
   Trash2,
   TriangleAlert,
 } from 'lucide-react';
@@ -41,6 +42,7 @@ import {
   ModelProviderForm,
   ModelMatchDialog,
   ModelTestDialog,
+  ProviderAvailabilityDialog,
 } from '@/components/models';
 import { ConfirmDialog, LoadingSpinner, ErrorState } from '@/components/common';
 import { updateModelProvider as updateModelProviderApi } from '@/lib/api';
@@ -77,6 +79,19 @@ function formatRate(value: number | null | undefined) {
   return `${(value * 100).toFixed(1)}%`;
 }
 
+/** True when the mapping is temporarily paused with a still-future window. */
+function isMappingPaused(mapping: ModelMappingProvider): boolean {
+  if (!mapping.is_active || !mapping.paused_until) return false;
+  return new Date(mapping.paused_until).getTime() > Date.now();
+}
+
+/** Minutes remaining in the pause window (>= 1), or null if not paused. */
+function pauseRemainingMinutes(mapping: ModelMappingProvider): number | null {
+  if (!isMappingPaused(mapping)) return null;
+  const ms = new Date(mapping.paused_until as string).getTime() - Date.now();
+  return Math.max(1, Math.round(ms / 60000));
+}
+
 
 export default function ModelDetailPage() {
   return (
@@ -105,6 +120,9 @@ function ModelDetailContent() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletingMapping, setDeletingMapping] = useState<ModelMappingProvider | null>(null);
   const [prioritizingMappingId, setPrioritizingMappingId] = useState<number | null>(null);
+  const [availabilityDialogOpen, setAvailabilityDialogOpen] = useState(false);
+  const [availabilityMapping, setAvailabilityMapping] =
+    useState<ModelMappingProvider | null>(null);
 
   const { data: model, isLoading, isError, refetch } = useModel(requestedModel, {
     refetchInterval: 30 * 1000,
@@ -130,6 +148,25 @@ function ModelDetailContent() {
   const handleEditMapping = (mapping: ModelMappingProvider) => {
     setEditingMapping(mapping);
     setFormOpen(true);
+  };
+
+  const handleOpenAvailability = (mapping: ModelMappingProvider) => {
+    setAvailabilityMapping(mapping);
+    setAvailabilityDialogOpen(true);
+  };
+
+  const handleAvailabilitySubmit = async (
+    data: ModelMappingProviderUpdate
+  ) => {
+    if (!availabilityMapping) return;
+    try {
+      await updateMutation.mutateAsync({ id: availabilityMapping.id, data });
+      setAvailabilityDialogOpen(false);
+      setAvailabilityMapping(null);
+      refetch();
+    } catch {
+      // Errors are surfaced via mutation onError toast
+    }
   };
 
   const handleDeleteMapping = (mapping: ModelMappingProvider) => {
@@ -412,7 +449,6 @@ function ModelDetailContent() {
                   {supportsBilling && <TableHead>{t('detail.billing')}</TableHead>}
                   <TableHead>{t('detail.priority')}</TableHead>
                   <TableHead>{t('detail.weight')}</TableHead>
-                  <TableHead>{t('detail.rules')}</TableHead>
                   <TableHead>{t('detail.status')}</TableHead>
                   <TableHead className="text-right">{t('detail.actions')}</TableHead>
                 </TableRow>
@@ -449,6 +485,23 @@ function ModelDetailContent() {
                         failureRate: healthFailureRate,
                       })
                     : undefined;
+                  const paused = isMappingPaused(mapping);
+                  const pausedMinutes = pauseRemainingMinutes(mapping);
+                  const pausedRemainingText =
+                    pausedMinutes === null
+                      ? ''
+                      : pausedMinutes < 60
+                        ? t('availability.remainingMinutes', { minutes: pausedMinutes })
+                        : (() => {
+                            const hours = Math.floor(pausedMinutes / 60);
+                            const mins = pausedMinutes % 60;
+                            return mins > 0
+                              ? t('availability.remainingHoursMinutes', {
+                                  hours,
+                                  minutes: mins,
+                                })
+                              : t('availability.remainingHours', { hours });
+                          })();
                   return (
                     <TableRow
                       key={mapping.id}
@@ -519,15 +572,6 @@ function ModelDetailContent() {
                       <TableCell>{mapping.priority}</TableCell>
                       <TableCell>{mapping.weight}</TableCell>
                       <TableCell>
-                        {mapping.provider_rules ? (
-                          <Badge variant="outline" className="text-blue-600">
-                            {t('detail.configured')}
-                          </Badge>
-                        ) : (
-                          <span className="text-muted-foreground">-</span>
-                        )}
-                      </TableCell>
-                      <TableCell>
                         {isProviderDisabledWhileMappingActive ? (
                           <TooltipProvider>
                             <Tooltip>
@@ -538,6 +582,29 @@ function ModelDetailContent() {
                               </TooltipTrigger>
                               <TooltipContent>
                                 {t('detail.providerDisabledTooltip')}
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : paused ? (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge
+                                  className="gap-1 border-transparent bg-amber-500/15 text-amber-700 dark:text-amber-300"
+                                  tabIndex={0}
+                                >
+                                  <PauseCircle
+                                    className="h-3 w-3"
+                                    aria-hidden="true"
+                                    suppressHydrationWarning
+                                  />
+                                  {t('availability.pausedBadge', {
+                                    remaining: pausedRemainingText,
+                                  })}
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-72 text-xs leading-relaxed">
+                                {t('availability.pausedStatusTooltip')}
                               </TooltipContent>
                             </Tooltip>
                           </TooltipProvider>
@@ -577,6 +644,21 @@ function ModelDetailContent() {
                               </Tooltip>
                             </TooltipProvider>
                           ) : null}
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleOpenAvailability(mapping)}
+                            title={t('availability.title')}
+                          >
+                            <PauseCircle
+                              className={
+                                mapping.is_active && isMappingPaused(mapping)
+                                  ? 'h-4 w-4 text-amber-600'
+                                  : 'h-4 w-4'
+                              }
+                              suppressHydrationWarning
+                            />
+                          </Button>
                           <Button
                             variant="ghost"
                             size="icon"
@@ -683,6 +765,14 @@ function ModelDetailContent() {
         open={matchDialogOpen}
         onOpenChange={setMatchDialogOpen}
         requestedModel={requestedModel}
+      />
+
+      <ProviderAvailabilityDialog
+        open={availabilityDialogOpen}
+        onOpenChange={setAvailabilityDialogOpen}
+        mapping={availabilityMapping}
+        onSubmit={handleAvailabilitySubmit}
+        loading={updateMutation.isPending}
       />
 
       <ConfirmDialog

--- a/frontend/src/components/models/ProviderAvailabilityDialog.tsx
+++ b/frontend/src/components/models/ProviderAvailabilityDialog.tsx
@@ -1,0 +1,281 @@
+/**
+ * Provider Availability Dialog
+ *
+ * Lets the user switch a single model-provider mapping between three states:
+ *  - Available        → { is_active: true, paused_until: null }
+ *  - Temporarily paused → { is_active: true, paused_until: now + duration }
+ *  - Permanently disabled → { is_active: false }
+ *
+ * Paused mappings stay in the candidate pool but are scheduled last, so they
+ * are only used once all non-paused providers have failed. The window ends
+ * automatically at paused_until (no scheduled job required).
+ */
+
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CheckCircle2, PauseCircle, Ban } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import type { ModelMappingProvider, ModelMappingProviderUpdate } from '@/types/model';
+import { cn } from '@/lib/utils';
+
+type AvailabilityMode = 'available' | 'paused' | 'disabled';
+
+/** Duration presets in minutes. 1h (60) is the default. */
+const DURATION_PRESETS = [30, 60, 180, 720, 1440] as const;
+const DEFAULT_DURATION_MINUTES = 60;
+
+interface ProviderAvailabilityDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mapping: ModelMappingProvider | null;
+  onSubmit: (data: ModelMappingProviderUpdate) => void | Promise<void>;
+  loading?: boolean;
+}
+
+function isPausedNow(mapping: ModelMappingProvider | null): boolean {
+  if (!mapping || !mapping.is_active || !mapping.paused_until) return false;
+  return new Date(mapping.paused_until).getTime() > Date.now();
+}
+
+/** Minutes remaining in the pause window (>= 1), or null if not paused. */
+function pauseRemainingMinutes(mapping: ModelMappingProvider | null): number | null {
+  if (!isPausedNow(mapping)) return null;
+  const ms = new Date(mapping!.paused_until as string).getTime() - Date.now();
+  return Math.max(1, Math.round(ms / 60000));
+}
+
+export function ProviderAvailabilityDialog({
+  open,
+  onOpenChange,
+  mapping,
+  onSubmit,
+  loading = false,
+}: ProviderAvailabilityDialogProps) {
+  const t = useTranslations('models');
+  const tCommon = useTranslations('common');
+
+  const [mode, setMode] = useState<AvailabilityMode>('available');
+  // Selected preset (minutes) or 'custom'.
+  const [durationChoice, setDurationChoice] = useState<number | 'custom'>(
+    DEFAULT_DURATION_MINUTES
+  );
+  const [customMinutes, setCustomMinutes] = useState<string>('');
+
+  // Reset local state to reflect the mapping's current state each time it opens.
+  useEffect(() => {
+    if (!open) return;
+    const nextMode: AvailabilityMode =
+      mapping && mapping.is_active === false
+        ? 'disabled'
+        : isPausedNow(mapping)
+          ? 'paused'
+          : 'available';
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setMode(nextMode);
+    setDurationChoice(DEFAULT_DURATION_MINUTES);
+    setCustomMinutes('');
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [open, mapping]);
+
+  const remainingMinutes = pauseRemainingMinutes(mapping);
+  const remainingLabel = (() => {
+    if (remainingMinutes === null) return null;
+    if (remainingMinutes < 60)
+      return t('availability.remainingMinutes', { minutes: remainingMinutes });
+    const hours = Math.floor(remainingMinutes / 60);
+    const mins = remainingMinutes % 60;
+    return mins > 0
+      ? t('availability.remainingHoursMinutes', { hours, minutes: mins })
+      : t('availability.remainingHours', { hours });
+  })();
+
+  const effectiveMinutes = (): number | null => {
+    if (durationChoice === 'custom') {
+      const parsed = parseInt(customMinutes, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) return null;
+      return parsed;
+    }
+    return durationChoice;
+  };
+
+  const canSubmit = mode !== 'paused' || effectiveMinutes() !== null;
+
+  const handleSubmit = async () => {
+    let data: ModelMappingProviderUpdate;
+    if (mode === 'disabled') {
+      // Clear any lingering pause window so re-enabling later starts fully available.
+      data = { is_active: false, paused_until: null };
+    } else if (mode === 'paused') {
+      const minutes = effectiveMinutes();
+      if (minutes === null) return;
+      const until = new Date(Date.now() + minutes * 60000).toISOString();
+      data = { is_active: true, paused_until: until };
+    } else {
+      data = { is_active: true, paused_until: null };
+    }
+    await onSubmit(data);
+  };
+
+  const durationLabel = (minutes: number): string => {
+    if (minutes < 60) return t('availability.durationMinutes', { minutes });
+    const hours = minutes / 60;
+    return t('availability.durationHours', { hours });
+  };
+
+  const options: Array<{
+    value: AvailabilityMode;
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    accent: string;
+  }> = [
+    {
+      value: 'available',
+      icon: <CheckCircle2 className="h-5 w-5 text-emerald-600" suppressHydrationWarning />,
+      title: t('availability.available'),
+      description: t('availability.availableDesc'),
+      accent: 'data-[selected=true]:border-emerald-500 data-[selected=true]:bg-emerald-500/5',
+    },
+    {
+      value: 'paused',
+      icon: <PauseCircle className="h-5 w-5 text-amber-600" suppressHydrationWarning />,
+      title: t('availability.paused'),
+      description: t('availability.pausedDesc'),
+      accent: 'data-[selected=true]:border-amber-500 data-[selected=true]:bg-amber-500/5',
+    },
+    {
+      value: 'disabled',
+      icon: <Ban className="h-5 w-5 text-red-600" suppressHydrationWarning />,
+      title: t('availability.disabled'),
+      description: t('availability.disabledDesc'),
+      accent: 'data-[selected=true]:border-red-500 data-[selected=true]:bg-red-500/5',
+    },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>{t('availability.title')}</DialogTitle>
+          <DialogDescription>
+            {mapping
+              ? t('availability.subtitle', {
+                  provider: mapping.provider_name,
+                  model: mapping.target_model_name,
+                })
+              : ''}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          {options.map((opt) => {
+            const selected = mode === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                data-selected={selected}
+                onClick={() => setMode(opt.value)}
+                className={cn(
+                  'flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  'hover:bg-muted/50',
+                  opt.accent
+                )}
+              >
+                <span className="mt-0.5">{opt.icon}</span>
+                <span className="flex-1">
+                  <span className="flex items-center gap-2 font-medium">
+                    {opt.title}
+                    {opt.value === 'paused' && remainingLabel && (
+                      <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-xs font-normal text-amber-700 dark:text-amber-300">
+                        {remainingLabel}
+                      </span>
+                    )}
+                  </span>
+                  <span className="mt-0.5 block text-sm text-muted-foreground">
+                    {opt.description}
+                  </span>
+                </span>
+                <span
+                  className={cn(
+                    'mt-1 h-4 w-4 shrink-0 rounded-full border-2',
+                    selected ? 'border-primary bg-primary' : 'border-muted-foreground/40'
+                  )}
+                />
+              </button>
+            );
+          })}
+        </div>
+
+        {mode === 'paused' && (
+          <div className="space-y-3 rounded-lg border bg-muted/30 p-3">
+            <Label className="text-sm">{t('availability.durationLabel')}</Label>
+            <div className="flex flex-wrap gap-2">
+              {DURATION_PRESETS.map((minutes) => (
+                <Button
+                  key={minutes}
+                  type="button"
+                  size="sm"
+                  variant={durationChoice === minutes ? 'default' : 'outline'}
+                  onClick={() => setDurationChoice(minutes)}
+                >
+                  {durationLabel(minutes)}
+                </Button>
+              ))}
+              <Button
+                type="button"
+                size="sm"
+                variant={durationChoice === 'custom' ? 'default' : 'outline'}
+                onClick={() => setDurationChoice('custom')}
+              >
+                {t('availability.customDuration')}
+              </Button>
+            </div>
+            {durationChoice === 'custom' && (
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={customMinutes}
+                  onChange={(e) => setCustomMinutes(e.target.value)}
+                  placeholder={t('availability.customPlaceholder')}
+                  className="w-32"
+                />
+                <span className="text-sm text-muted-foreground">
+                  {t('availability.minutesUnit')}
+                </span>
+              </div>
+            )}
+            {remainingLabel && (
+              <p className="text-xs text-muted-foreground">
+                {t('availability.overrideHint')}
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            {tCommon('cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading || !canSubmit}>
+            {loading ? tCommon('processing') : tCommon('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/models/index.ts
+++ b/frontend/src/components/models/index.ts
@@ -10,3 +10,4 @@ export * from './ModelMatchDialog';
 export * from './ModelTestDialog';
 export * from './BillingDisplay';
 export * from './ModelProviderBillingFields';
+export * from './ProviderAvailabilityDialog';

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -100,6 +100,8 @@ export interface ModelMappingProvider {
   priority: number;
   weight: number;
   is_active: boolean;
+  /** Temporary pause window end (UTC ISO). Future value = temporarily paused (scheduled last). */
+  paused_until?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -207,6 +209,8 @@ export interface ModelMappingProviderUpdate {
   priority?: number;
   weight?: number;
   is_active?: boolean;
+  /** Temporary pause window end (UTC ISO). Future = pause, explicit null = resume now. */
+  paused_until?: string | null;
 }
 
 /** Bulk upgrade provider mappings by provider + current target model name */


### PR DESCRIPTION
## Summary

- Add `backend/app/common/protocol_conversion.py` implementing request/response/stream conversion between the OpenAI and Anthropic protocols using `litellm`'s Anthropic transformation utilities.
  - `convert_request_for_supplier`: converts an incoming request body/path to the supplier's protocol format.
  - `convert_response_for_user`: converts a non-streaming supplier response back to the requester's protocol.
  - `convert_stream_for_user`: converts SSE streaming responses between OpenAI chat-completion-chunk format and Anthropic message-event format.
- Update `proxy_service.py` to integrate protocol conversion into the proxy request/response flow when the client protocol differs from the supplier protocol.
- Add `litellm` (and related) dependencies to `pyproject.toml`/`requirements.txt`.
- Add unit tests for the new protocol conversion module (`test_protocol_conversion.py`).
- Adjust existing `test_proxy_service_protocol_matching.py` tests to match the new proxy service behavior.

## Notes

- Only Chat/Messages endpoints are supported for conversion:
  - OpenAI: `/v1/chat/completions`
  - Anthropic: `/v1/messages`
- Unsupported conversions raise a `ServiceError` with code `unsupported_protocol_conversion`.