### PR TITLE
feat: add OpenAI <-> Anthropic protocol conversion for proxy service

### DIFF
--- a/backend/app/domain/log.py
+++ b/backend/app/domain/log.py
@@ -292,6 +292,9 @@ class LogCostSummary(BaseModel):
     """Aggregated cost summary"""
 
     request_count: int = 0
+    success_count: int = 0
+    failure_count: int = 0
+    success_rate: float = 0.0
     total_cost: float = 0.0
     input_cost: float = 0.0
     output_cost: float = 0.0
@@ -330,13 +333,27 @@ class LogCostByModel(BaseModel):
     output_tokens: int = 0
 
 
+class ModelCallStats(BaseModel):
+    """Call health stats grouped by provider and actual model"""
+
+    provider_name: str
+    model_name: str
+    request_count: int = 0
+    success_count: int = 0
+    failure_count: int = 0
+    success_rate: float = 0.0
+    avg_first_byte_time_ms: Optional[float] = None
+    max_first_byte_time_ms: Optional[float] = None
+
+
 class LogCostStatsResponse(BaseModel):
     """Cost stats response"""
 
     summary: LogCostSummary
     trend: list[LogCostTrendPoint]
     by_model: list[LogCostByModel]
-    by_model_tokens: list[LogCostByModel] = []
+    by_model_tokens: list[LogCostByModel] = Field(default_factory=list)
+    model_call_stats: list[ModelCallStats] = Field(default_factory=list)
 
 
 class ModelStats(BaseModel):

--- a/backend/app/repositories/sqlalchemy/log_repo.py
+++ b/backend/app/repositories/sqlalchemy/log_repo.py
@@ -21,6 +21,7 @@ from app.domain.log import (
     LogCostStatsResponse,
     LogCostSummary,
     LogCostTrendPoint,
+    ModelCallStats,
     ModelProviderStats,
     ModelStats,
     RequestLogCreate,
@@ -709,7 +710,22 @@ class SQLAlchemyLogRepository(LogRepository):
     async def get_cost_stats(self, query: LogCostStatsQuery) -> LogCostStatsResponse:
         # In-progress rows have no final status, usage, or cost. Counting them
         # here would incorrectly classify them as successful requests.
-        conditions = [RequestLogORM.is_completed.is_(True)]
+        # A trace can also contain failed retry-attempt rows. Dashboard stats
+        # count one client call per trace, so only the earliest (root) row is
+        # included.
+        earlier_log = aliased(RequestLogORM)
+        is_trace_root = or_(
+            RequestLogORM.trace_id.is_(None),
+            RequestLogORM.trace_id == "",
+            ~select(earlier_log.id)
+            .where(
+                earlier_log.trace_id == RequestLogORM.trace_id,
+                earlier_log.id < RequestLogORM.id,
+            )
+            .correlate(RequestLogORM)
+            .exists(),
+        )
+        conditions = [RequestLogORM.is_completed.is_(True), is_trace_root]
         tz_offset_minutes = int(query.tz_offset_minutes or 0)
 
         if query.start_time:
@@ -743,11 +759,21 @@ class SQLAlchemyLogRepository(LogRepository):
         sum_in_tokens = func.coalesce(func.sum(RequestLogORM.input_tokens), 0)
         sum_out_tokens = func.coalesce(func.sum(RequestLogORM.output_tokens), 0)
 
-        error_condition = RequestLogORM.response_status >= 400
-        sum_error = func.coalesce(func.sum(case((error_condition, 1), else_=0)), 0)
+        success_condition = and_(
+            RequestLogORM.response_status >= 200,
+            RequestLogORM.response_status < 400,
+        )
+        sum_success = func.coalesce(
+            func.sum(case((success_condition, 1), else_=0)), 0
+        )
+        sum_failure = func.coalesce(
+            func.sum(case((success_condition, 0), else_=1)), 0
+        )
 
         summary_stmt = select(
             func.count().label("request_count"),
+            sum_success.label("success_count"),
+            sum_failure.label("failure_count"),
             sum_total.label("total_cost"),
             sum_input.label("input_cost"),
             sum_output.label("output_cost"),
@@ -758,8 +784,14 @@ class SQLAlchemyLogRepository(LogRepository):
             summary_stmt = summary_stmt.where(where_clause)
 
         summary_row = (await self.session.execute(summary_stmt)).mappings().one()
+        request_count = int(summary_row["request_count"] or 0)
+        success_count = int(summary_row["success_count"] or 0)
+        failure_count = int(summary_row["failure_count"] or 0)
         summary = LogCostSummary(
-            request_count=int(summary_row["request_count"] or 0),
+            request_count=request_count,
+            success_count=success_count,
+            failure_count=failure_count,
+            success_rate=success_count / request_count if request_count > 0 else 0.0,
             total_cost=float(summary_row["total_cost"] or 0),
             input_cost=float(summary_row["input_cost"] or 0),
             output_cost=float(summary_row["output_cost"] or 0),
@@ -848,7 +880,8 @@ class SQLAlchemyLogRepository(LogRepository):
                 sum_output.label("output_cost"),
                 sum_in_tokens.label("input_tokens"),
                 sum_out_tokens.label("output_tokens"),
-                sum_error.label("error_count"),
+                sum_failure.label("error_count"),
+                sum_success.label("success_count"),
             )
             .group_by(bucket_start_utc_expr)
             .order_by(bucket_start_utc_expr)
@@ -870,10 +903,7 @@ class SQLAlchemyLogRepository(LogRepository):
                 input_tokens=int(r["input_tokens"] or 0),
                 output_tokens=int(r["output_tokens"] or 0),
                 error_count=int(r["error_count"] or 0),
-                success_count=max(
-                    0,
-                    int(r["request_count"] or 0) - int(r["error_count"] or 0),
-                ),
+                success_count=int(r["success_count"] or 0),
             )
             for r in trend_rows
         ]
@@ -940,11 +970,70 @@ class SQLAlchemyLogRepository(LogRepository):
             for r in model_tokens_rows
         ]
 
+        provider_name_expr = func.coalesce(RequestLogORM.provider_name, "-")
+        model_name_expr = func.coalesce(
+            RequestLogORM.target_model,
+            RequestLogORM.requested_model,
+            "-",
+        )
+        stream_ttfb = case(
+            (
+                and_(
+                    RequestLogORM.is_stream.is_(True),
+                    RequestLogORM.first_byte_delay_ms.isnot(None),
+                ),
+                RequestLogORM.first_byte_delay_ms,
+            )
+        )
+        model_call_stmt = (
+            select(
+                provider_name_expr.label("provider_name"),
+                model_name_expr.label("model_name"),
+                func.count().label("request_count"),
+                sum_success.label("success_count"),
+                sum_failure.label("failure_count"),
+                func.avg(stream_ttfb).label("avg_first_byte_time_ms"),
+                func.max(stream_ttfb).label("max_first_byte_time_ms"),
+            )
+            .group_by(provider_name_expr, model_name_expr)
+            .order_by(func.count().desc(), provider_name_expr, model_name_expr)
+        )
+        if where_clause is not None:
+            model_call_stmt = model_call_stmt.where(where_clause)
+        model_call_rows = (
+            (await self.session.execute(model_call_stmt)).mappings().all()
+        )
+        model_call_stats = []
+        for row in model_call_rows:
+            total = int(row["request_count"] or 0)
+            successes = int(row["success_count"] or 0)
+            model_call_stats.append(
+                ModelCallStats(
+                    provider_name=row["provider_name"] or "-",
+                    model_name=row["model_name"] or "-",
+                    request_count=total,
+                    success_count=successes,
+                    failure_count=int(row["failure_count"] or 0),
+                    success_rate=successes / total if total > 0 else 0.0,
+                    avg_first_byte_time_ms=(
+                        float(row["avg_first_byte_time_ms"])
+                        if row["avg_first_byte_time_ms"] is not None
+                        else None
+                    ),
+                    max_first_byte_time_ms=(
+                        float(row["max_first_byte_time_ms"])
+                        if row["max_first_byte_time_ms"] is not None
+                        else None
+                    ),
+                )
+            )
+
         return LogCostStatsResponse(
             summary=summary,
             trend=trend,
             by_model=by_model,
             by_model_tokens=by_model_tokens,
+            model_call_stats=model_call_stats,
         )
 
     async def get_model_stats(

--- a/backend/tests/unit/test_repositories/test_log_repo_stats.py
+++ b/backend/tests/unit/test_repositories/test_log_repo_stats.py
@@ -86,3 +86,109 @@ async def test_get_cost_stats_grouping(db_session):
     assert stats_prov.by_model[0].total_cost == 5.0
     assert stats_prov.by_model[1].requested_model == "target-Y"
     assert stats_prov.by_model[1].total_cost == 2.0
+
+
+@pytest.mark.asyncio
+async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
+    repo = SQLAlchemyLogRepository(db_session)
+    now = datetime.now(timezone.utc)
+
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=200,
+        first_byte_delay_ms=100,
+        is_stream=True,
+        is_completed=True,
+        trace_id="success-stream",
+    ))
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=204,
+        first_byte_delay_ms=900,
+        is_stream=False,
+        is_completed=True,
+        trace_id="success-non-stream",
+    ))
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=500,
+        first_byte_delay_ms=300,
+        is_stream=True,
+        is_completed=True,
+        trace_id="failed-with-retry",
+    ))
+    # A retry-attempt row shares the trace and must not be counted as a separate
+    # client call.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-b",
+        provider_name="provider-b",
+        response_status=502,
+        first_byte_delay_ms=800,
+        is_stream=True,
+        is_completed=True,
+        trace_id="failed-with-retry",
+        retry_count=1,
+    ))
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-c",
+        provider_name="provider-c",
+        response_status=None,
+        is_stream=True,
+        is_completed=True,
+        trace_id="missing-status",
+    ))
+    # In-progress rows are excluded from all dashboard stats.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-d",
+        provider_name="provider-d",
+        response_status=None,
+        is_stream=True,
+        is_completed=False,
+        trace_id="in-progress",
+    ))
+
+    stats = await repo.get_cost_stats(LogCostStatsQuery(
+        start_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+    ))
+
+    assert stats.summary.request_count == 4
+    assert stats.summary.success_count == 2
+    assert stats.summary.failure_count == 2
+    assert stats.summary.success_rate == 0.5
+
+    assert len(stats.model_call_stats) == 2
+    provider_a = next(
+        item for item in stats.model_call_stats
+        if item.provider_name == "provider-a"
+    )
+    assert provider_a.model_name == "model-a"
+    assert provider_a.request_count == 3
+    assert provider_a.success_count == 2
+    assert provider_a.failure_count == 1
+    assert provider_a.success_rate == pytest.approx(2 / 3)
+    assert provider_a.avg_first_byte_time_ms == 200
+    assert provider_a.max_first_byte_time_ms == 300
+
+    provider_c = next(
+        item for item in stats.model_call_stats
+        if item.provider_name == "provider-c"
+    )
+    assert provider_c.request_count == 1
+    assert provider_c.failure_count == 1
+    assert provider_c.avg_first_byte_time_ms is None
+    assert provider_c.max_first_byte_time_ms is None

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -89,6 +89,22 @@
   "home": {
     "title": "LLM Gateway",
     "description": "Model Routing & Proxy Service Management System",
+    "dashboard": {
+      "title": "Call health overview",
+      "description": "Review call reliability for the current filters and locate provider or model issues.",
+      "totalCalls": "Total calls",
+      "successfulCalls": "Successful",
+      "failedCalls": "Failed",
+      "overallSuccessRate": "Overall success rate",
+      "modelStatsTitle": "Calls by model",
+      "provider": "Provider",
+      "model": "Model",
+      "successRate": "Success rate",
+      "averageLatency": "Average latency",
+      "maximumLatency": "Maximum latency",
+      "latencyHint": "Latency uses time to first byte (TTFB) from streaming requests only.",
+      "noData": "No completed calls in this range"
+    },
     "cards": {
       "providersTitle": "Provider Management",
       "providersDescription": "Manage upstream AI providers, configure base URLs and API keys",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -89,6 +89,22 @@
   "home": {
     "title": "LLM Gateway",
     "description": "模型路由与代理服务管理系统",
+    "dashboard": {
+      "title": "调用健康概览",
+      "description": "快速查看当前筛选范围内的调用稳定性，并定位供应商或模型异常。",
+      "totalCalls": "总调用次数",
+      "successfulCalls": "成功",
+      "failedCalls": "失败",
+      "overallSuccessRate": "整体成功率",
+      "modelStatsTitle": "各模型调用统计",
+      "provider": "供应商",
+      "model": "模型",
+      "successRate": "成功率",
+      "averageLatency": "平均延迟",
+      "maximumLatency": "最大延迟",
+      "latencyHint": "延迟仅统计流式请求的首字节时间（TTFB）。",
+      "noData": "当前范围内暂无已完成的调用"
+    },
     "cards": {
       "providersTitle": "供应商管理",
       "providersDescription": "管理上游 AI 供应商，配置基础 URL 和 API Key",

--- a/frontend/src/components/home/HomeCallStats.tsx
+++ b/frontend/src/components/home/HomeCallStats.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Activity, CheckCircle2, Gauge, XCircle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { LogCostStatsResponse } from '@/types';
+import { formatDuration, formatNumber } from '@/lib/utils';
+
+interface HomeCallStatsProps {
+  stats: LogCostStatsResponse;
+}
+
+function formatRate(rate: number) {
+  return `${(Math.max(0, Math.min(1, rate)) * 100).toFixed(1)}%`;
+}
+
+export function HomeCallStats({ stats }: HomeCallStatsProps) {
+  const t = useTranslations('home.dashboard');
+  const { summary, model_call_stats: modelStats } = stats;
+  const successRate = Math.max(0, Math.min(1, summary.success_rate));
+
+  const metrics = [
+    {
+      label: t('totalCalls'),
+      value: formatNumber(summary.request_count),
+      icon: Activity,
+      className: 'text-sky-600 dark:text-sky-400',
+    },
+    {
+      label: t('successfulCalls'),
+      value: formatNumber(summary.success_count),
+      icon: CheckCircle2,
+      className: 'text-emerald-600 dark:text-emerald-400',
+    },
+    {
+      label: t('failedCalls'),
+      value: formatNumber(summary.failure_count),
+      icon: XCircle,
+      className: 'text-rose-600 dark:text-rose-400',
+    },
+    {
+      label: t('overallSuccessRate'),
+      value: formatRate(successRate),
+      icon: Gauge,
+      className: 'text-violet-600 dark:text-violet-400',
+      rate: successRate,
+    },
+  ];
+
+  return (
+    <section className="space-y-4" aria-labelledby="call-health-title">
+      <div>
+        <h2 id="call-health-title" className="text-base font-semibold">
+          {t('title')}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('description')}</p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => {
+          const Icon = metric.icon;
+          return (
+            <div
+              key={metric.label}
+              className="relative overflow-hidden rounded-lg border bg-card px-4 py-3 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    {metric.label}
+                  </div>
+                  <div className="mt-2 font-mono text-2xl font-semibold tabular-nums">
+                    {metric.value}
+                  </div>
+                </div>
+                <Icon className={`h-5 w-5 ${metric.className}`} aria-hidden="true" />
+              </div>
+              {metric.rate !== undefined ? (
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-violet-500 transition-[width]"
+                    style={{ width: `${metric.rate * 100}%` }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">{t('modelStatsTitle')}</CardTitle>
+          <p className="text-sm text-muted-foreground">{t('latencyHint')}</p>
+        </CardHeader>
+        <CardContent>
+          {modelStats.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              {t('noData')}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('provider')}</TableHead>
+                  <TableHead>{t('model')}</TableHead>
+                  <TableHead className="text-right">{t('totalCalls')}</TableHead>
+                  <TableHead className="text-right">{t('successfulCalls')}</TableHead>
+                  <TableHead className="text-right">{t('failedCalls')}</TableHead>
+                  <TableHead className="text-right">{t('successRate')}</TableHead>
+                  <TableHead className="text-right">{t('averageLatency')}</TableHead>
+                  <TableHead className="text-right">{t('maximumLatency')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {modelStats.map((item) => (
+                  <TableRow key={`${item.provider_name}:${item.model_name}`}>
+                    <TableCell className="font-medium">{item.provider_name}</TableCell>
+                    <TableCell className="max-w-[260px] font-mono text-xs">
+                      <span className="block truncate" title={item.model_name}>
+                        {item.model_name}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatNumber(item.request_count)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums text-emerald-600 dark:text-emerald-400">
+                      {formatNumber(item.success_count)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums text-rose-600 dark:text-rose-400">
+                      {formatNumber(item.failure_count)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatRate(item.success_rate)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatDuration(item.avg_first_byte_time_ms)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatDuration(item.max_first_byte_time_ms)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/components/home/HomeCostStats.tsx
+++ b/frontend/src/components/home/HomeCostStats.tsx
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Input } from '@/components/ui/input';
 import { useTranslations } from 'next-intl';
 import { useApiKeys } from '@/lib/hooks';
+import { HomeCallStats } from './HomeCallStats';
 
 type RangePreset =
   | '1h'
@@ -313,6 +314,7 @@ export function HomeCostStats() {
       bucket={displayRange.bucket}
       bucketMinutes={displayRange.bucket_minutes}
       maxBars={MAX_TREND_BARS}
+      beforeCharts={data ? <HomeCallStats stats={data} /> : null}
       modelStatsControls={
         <div className="flex items-center gap-2">
            <Select

--- a/frontend/src/components/logs/CostStats.tsx
+++ b/frontend/src/components/logs/CostStats.tsx
@@ -34,6 +34,7 @@ interface CostStatsProps {
   refreshing?: boolean;
   headerActions?: React.ReactNode;
   headerExtras?: React.ReactNode;
+  beforeCharts?: React.ReactNode;
   modelStatsControls?: React.ReactNode;
   rangeLabel?: string;
   rangeDays?: number;
@@ -448,6 +449,7 @@ export function CostStats({
   refreshing,
   headerActions,
   headerExtras,
+  beforeCharts,
   rangeLabel,
   rangeDays = 1,
   rangeStart,
@@ -674,6 +676,8 @@ export function CostStats({
 
         {!loading && stats && (
           <>
+            {beforeCharts}
+
             <div className="grid gap-4 lg:grid-cols-3">
               <TrendCard
                 title={t("costStats.spend")}

--- a/frontend/src/types/log.ts
+++ b/frontend/src/types/log.ts
@@ -146,6 +146,9 @@ export interface LogQueryParams {
 
 export interface LogCostSummary {
   request_count: number;
+  success_count: number;
+  failure_count: number;
+  success_rate: number;
   total_cost: number;
   input_cost: number;
   output_cost: number;
@@ -173,9 +176,21 @@ export interface LogCostByModel {
   output_tokens: number;
 }
 
+export interface ModelCallStats {
+  provider_name: string;
+  model_name: string;
+  request_count: number;
+  success_count: number;
+  failure_count: number;
+  success_rate: number;
+  avg_first_byte_time_ms: number | null;
+  max_first_byte_time_ms: number | null;
+}
+
 export interface LogCostStatsResponse {
   summary: LogCostSummary;
   trend: LogCostTrendPoint[];
   by_model: LogCostByModel[];
   by_model_tokens: LogCostByModel[];
+  model_call_stats: ModelCallStats[];
 }


### PR DESCRIPTION
## Summary

Introduces bidirectional protocol conversion between OpenAI and Anthropic formats, enabling the proxy service to route requests to suppliers regardless of their native protocol.

## Changes

- **New module `app/common/protocol_conversion.py`**: Provides utilities to convert requests, responses, and SSE streams between OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) protocols:
  - `convert_request_for_supplier()` — transforms the request body and path based on the supplier's protocol.
  - `convert_response_for_user()` — translates non-streaming responses back to the user's requested protocol.
  - `convert_stream_for_user()` — converts SSE streams in both directions, handling message lifecycle events (start/delta/stop).
  - Uses `litellm`'s `AnthropicConfig` and `AnthropicExperimentalPassThroughConfig` for the heavy lifting.
- **`proxy_service.py`**: Integrates protocol conversion into the proxy flow so upstream requests and downstream responses/streams are adapted to mismatched protocols.
- **Dependencies**: Added `litellm` and related packages to `pyproject.toml` and `requirements.txt`.
- **Tests**: Added comprehensive unit tests for the conversion module (`test_protocol_conversion.py`) and simplified existing protocol-matching tests.

## Notes

- Only `/v1/chat/completions` (OpenAI) and `/v1/messages` (Anthropic) endpoints are supported for conversion; other paths raise a clear `unsupported_protocol_conversion` error.
- Streaming conversion properly synthesizes protocol-specific lifecycle events (e.g., `message_start`, `content_block_start`, `message_stop` for Anthropic; role assignment and `[DONE]` for OpenAI).