### PR TITLE
feat: add OpenAI <-> Anthropic protocol conversion

### DIFF
--- a/backend/app/repositories/sqlalchemy/log_repo.py
+++ b/backend/app/repositories/sqlalchemy/log_repo.py
@@ -493,7 +493,6 @@ class SQLAlchemyLogRepository(LogRepository):
             .correlate(RequestLogORM)
             .exists(),
         )
-
         # Build base query with only summary columns. Pagination is deliberately
         # applied to roots before retry attempt rows are loaded.
         stmt = select(*_SUMMARY_COLUMNS)
@@ -725,33 +724,51 @@ class SQLAlchemyLogRepository(LogRepository):
             .correlate(RequestLogORM)
             .exists(),
         )
-        conditions = [RequestLogORM.is_completed.is_(True), is_trace_root]
+        later_log = aliased(RequestLogORM)
+        has_later_trace_row = and_(
+            RequestLogORM.trace_id.isnot(None),
+            RequestLogORM.trace_id != "",
+            select(later_log.id)
+            .where(
+                later_log.trace_id == RequestLogORM.trace_id,
+                later_log.id > RequestLogORM.id,
+            )
+            .correlate(RequestLogORM)
+            .exists(),
+        )
+        base_conditions = [RequestLogORM.is_completed.is_(True)]
         tz_offset_minutes = int(query.tz_offset_minutes or 0)
 
         if query.start_time:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.request_time >= to_utc_naive(query.start_time)
             )
         if query.end_time:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.request_time <= to_utc_naive(query.end_time)
             )
         if query.provider_id:
-            conditions.append(RequestLogORM.provider_id == query.provider_id)
+            base_conditions.append(RequestLogORM.provider_id == query.provider_id)
         if query.api_key_id:
-            conditions.append(RequestLogORM.api_key_id == query.api_key_id)
+            base_conditions.append(RequestLogORM.api_key_id == query.api_key_id)
         if query.api_key_name:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.api_key_name.ilike(f"%{query.api_key_name}%")
             )
         if query.user_id:
-            conditions.append(RequestLogORM.user_id.ilike(f"%{query.user_id}%"))
+            base_conditions.append(RequestLogORM.user_id.ilike(f"%{query.user_id}%"))
         if query.requested_model:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.requested_model.ilike(f"%{query.requested_model}%")
             )
 
-        where_clause = and_(*conditions) if conditions else None
+        # Summary, trends, costs, and token usage describe client requests and
+        # therefore use one root row per trace.
+        root_where_clause = and_(*base_conditions, is_trace_root)
+        # Per-provider/model health describes actual upstream attempts. It must
+        # include failed retry rows; otherwise a later successful fallback hides
+        # the original model's 4xx/5xx failures.
+        attempt_where_clause = and_(*base_conditions)
 
         sum_total = func.coalesce(func.sum(RequestLogORM.total_cost), 0)
         sum_input = func.coalesce(func.sum(RequestLogORM.input_cost), 0)
@@ -769,6 +786,15 @@ class SQLAlchemyLogRepository(LogRepository):
         sum_failure = func.coalesce(
             func.sum(case((success_condition, 0), else_=1)), 0
         )
+        is_upstream_attempt = or_(
+            # Failed retry rows represent each actual unsuccessful upstream call.
+            ~is_trace_root,
+            # Successful attempts are stored only on the root row.
+            success_condition,
+            # Keep standalone failures that have no retry-attempt detail rows,
+            # such as model resolution or forwarding setup failures.
+            ~has_later_trace_row,
+        )
 
         summary_stmt = select(
             func.count().label("request_count"),
@@ -780,8 +806,7 @@ class SQLAlchemyLogRepository(LogRepository):
             sum_in_tokens.label("input_tokens"),
             sum_out_tokens.label("output_tokens"),
         )
-        if where_clause is not None:
-            summary_stmt = summary_stmt.where(where_clause)
+        summary_stmt = summary_stmt.where(root_where_clause)
 
         summary_row = (await self.session.execute(summary_stmt)).mappings().one()
         request_count = int(summary_row["request_count"] or 0)
@@ -886,8 +911,7 @@ class SQLAlchemyLogRepository(LogRepository):
             .group_by(bucket_start_utc_expr)
             .order_by(bucket_start_utc_expr)
         )
-        if where_clause is not None:
-            trend_stmt = trend_stmt.where(where_clause)
+        trend_stmt = trend_stmt.where(root_where_clause)
         trend_rows = (await self.session.execute(trend_stmt)).mappings().all()
         trend = [
             LogCostTrendPoint(
@@ -927,8 +951,7 @@ class SQLAlchemyLogRepository(LogRepository):
             .order_by(sum_total.desc())
             .limit(50)
         )
-        if where_clause is not None:
-            by_model_stmt = by_model_stmt.where(where_clause)
+        by_model_stmt = by_model_stmt.where(root_where_clause)
         model_rows = (await self.session.execute(by_model_stmt)).mappings().all()
         by_model = [
             LogCostByModel(
@@ -954,8 +977,7 @@ class SQLAlchemyLogRepository(LogRepository):
             .order_by((sum_in_tokens + sum_out_tokens).desc())
             .limit(50)
         )
-        if where_clause is not None:
-            by_model_tokens_stmt = by_model_tokens_stmt.where(where_clause)
+        by_model_tokens_stmt = by_model_tokens_stmt.where(root_where_clause)
         model_tokens_rows = (
             (await self.session.execute(by_model_tokens_stmt)).mappings().all()
         )
@@ -998,8 +1020,10 @@ class SQLAlchemyLogRepository(LogRepository):
             .group_by(provider_name_expr, model_name_expr)
             .order_by(func.count().desc(), provider_name_expr, model_name_expr)
         )
-        if where_clause is not None:
-            model_call_stmt = model_call_stmt.where(where_clause)
+        model_call_stmt = model_call_stmt.where(
+            attempt_where_clause,
+            is_upstream_attempt,
+        )
         model_call_rows = (
             (await self.session.execute(model_call_stmt)).mappings().all()
         )

--- a/backend/tests/unit/test_repositories/test_log_repo_stats.py
+++ b/backend/tests/unit/test_repositories/test_log_repo_stats.py
@@ -118,6 +118,19 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     await repo.create(RequestLogCreate(
         request_time=now,
         requested_model="chat",
+        target_model="model-b",
+        provider_name="provider-b",
+        response_status=502,
+        first_byte_delay_ms=800,
+        is_stream=True,
+        is_completed=True,
+        trace_id="failed-with-retry",
+    ))
+    # Retry-attempt rows share the trace. They must not be counted as separate
+    # client calls in the summary, but each is a real upstream model call.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
         target_model="model-a",
         provider_name="provider-a",
         response_status=500,
@@ -125,9 +138,10 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
         is_stream=True,
         is_completed=True,
         trace_id="failed-with-retry",
+        retry_count=1,
     ))
-    # A retry-attempt row shares the trace and must not be counted as a separate
-    # client call.
+    # The final failed attempt is also present in the root row. Per-model stats
+    # must count this attempt row once and exclude the duplicate root failure.
     await repo.create(RequestLogCreate(
         request_time=now,
         requested_model="chat",
@@ -138,7 +152,7 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
         is_stream=True,
         is_completed=True,
         trace_id="failed-with-retry",
-        retry_count=1,
+        retry_count=2,
     ))
     await repo.create(RequestLogCreate(
         request_time=now,
@@ -171,7 +185,7 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     assert stats.summary.failure_count == 2
     assert stats.summary.success_rate == 0.5
 
-    assert len(stats.model_call_stats) == 2
+    assert len(stats.model_call_stats) == 3
     provider_a = next(
         item for item in stats.model_call_stats
         if item.provider_name == "provider-a"
@@ -184,6 +198,18 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     assert provider_a.avg_first_byte_time_ms == 200
     assert provider_a.max_first_byte_time_ms == 300
 
+    provider_b = next(
+        item for item in stats.model_call_stats
+        if item.provider_name == "provider-b"
+    )
+    assert provider_b.model_name == "model-b"
+    assert provider_b.request_count == 1
+    assert provider_b.success_count == 0
+    assert provider_b.failure_count == 1
+    assert provider_b.success_rate == 0
+    assert provider_b.avg_first_byte_time_ms == 800
+    assert provider_b.max_first_byte_time_ms == 800
+
     provider_c = next(
         item for item in stats.model_call_stats
         if item.provider_name == "provider-c"
@@ -192,3 +218,55 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     assert provider_c.failure_count == 1
     assert provider_c.avg_first_byte_time_ms is None
     assert provider_c.max_first_byte_time_ms is None
+
+
+@pytest.mark.asyncio
+async def test_model_call_stats_keep_failed_attempt_before_successful_fallback(db_session):
+    repo = SQLAlchemyLogRepository(db_session)
+    now = datetime.now(timezone.utc)
+
+    # The root row contains the final successful fallback result.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-b",
+        provider_name="provider-b",
+        response_status=200,
+        first_byte_delay_ms=120,
+        is_stream=True,
+        is_completed=True,
+        trace_id="fallback-success",
+    ))
+    # The failed provider attempt is written as another row under the same trace.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=500,
+        first_byte_delay_ms=450,
+        is_stream=True,
+        is_completed=True,
+        trace_id="fallback-success",
+        retry_count=1,
+    ))
+
+    stats = await repo.get_cost_stats(LogCostStatsQuery(
+        start_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+    ))
+
+    # One client request ultimately succeeded.
+    assert stats.summary.request_count == 1
+    assert stats.summary.success_count == 1
+    assert stats.summary.failure_count == 0
+
+    by_provider = {
+        item.provider_name: item
+        for item in stats.model_call_stats
+    }
+    assert by_provider["provider-a"].success_count == 0
+    assert by_provider["provider-a"].failure_count == 1
+    assert by_provider["provider-a"].success_rate == 0
+    assert by_provider["provider-b"].success_count == 1
+    assert by_provider["provider-b"].failure_count == 0
+    assert by_provider["provider-b"].success_rate == 1

--- a/frontend/src/components/home/HomeCostStats.tsx
+++ b/frontend/src/components/home/HomeCostStats.tsx
@@ -314,7 +314,7 @@ export function HomeCostStats() {
       bucket={displayRange.bucket}
       bucketMinutes={displayRange.bucket_minutes}
       maxBars={MAX_TREND_BARS}
-      beforeCharts={data ? <HomeCallStats stats={data} /> : null}
+      afterContent={data ? <HomeCallStats stats={data} /> : null}
       modelStatsControls={
         <div className="flex items-center gap-2">
            <Select

--- a/frontend/src/components/logs/CostStats.tsx
+++ b/frontend/src/components/logs/CostStats.tsx
@@ -34,7 +34,7 @@ interface CostStatsProps {
   refreshing?: boolean;
   headerActions?: React.ReactNode;
   headerExtras?: React.ReactNode;
-  beforeCharts?: React.ReactNode;
+  afterContent?: React.ReactNode;
   modelStatsControls?: React.ReactNode;
   rangeLabel?: string;
   rangeDays?: number;
@@ -449,7 +449,7 @@ export function CostStats({
   refreshing,
   headerActions,
   headerExtras,
-  beforeCharts,
+  afterContent,
   rangeLabel,
   rangeDays = 1,
   rangeStart,
@@ -676,8 +676,6 @@ export function CostStats({
 
         {!loading && stats && (
           <>
-            {beforeCharts}
-
             <div className="grid gap-4 lg:grid-cols-3">
               <TrendCard
                 title={t("costStats.spend")}
@@ -909,6 +907,8 @@ export function CostStats({
                 </div>
               </div>
             </div>
+
+            {afterContent}
           </>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary

Introduces bidirectional protocol conversion between OpenAI and Anthropic Chat/Messages formats, allowing requests to be proxied to suppliers that use a different protocol than the client's request.

## Changes

- **New module `backend/app/common/protocol_conversion.py`** (~404 lines):
  - `normalize_protocol()` — validates and normalizes protocol identifiers (`openai` / `anthropic`).
  - `convert_request_for_supplier()` — converts request body/path when request protocol differs from supplier protocol (handles `max_completion_tokens` → `max_tokens` fallback).
  - `convert_response_for_user()` — converts non-streaming JSON responses between protocols.
  - `convert_stream_for_user()` — converts SSE byte streams between protocols, including Anthropic event sequence (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`) and OpenAI chunk format.
  - Leverages `litellm`'s `AnthropicConfig` and `AnthropicExperimentalPassThroughConfig` for transformation logic.

- **`backend/app/services/proxy_service.py`**: Integrated protocol conversion into the proxy pipeline.

- **Dependencies** (`pyproject.toml`, `requirements.txt`): Added required packages (including `litellm`).

- **Tests**:
  - `test_protocol_conversion.py` (194 lines) — new unit tests covering request/response/stream conversion.
  - `test_proxy_service_protocol_matching.py` — updated existing tests to align with new conversion logic.

## Supported Conversions

| Request | Supplier | Conversion |
|----------|----------|------------|
| OpenAI | Anthropic | ✅ |
| Anthropic | OpenAI | ✅ |
| Same protocol | Same | Pass-through (model override only) |

Both streaming and non-streaming modes are supported.