### PR TITLE
feat(dashboard): add per-model call health statistics

### DIFF
--- a/backend/app/domain/log.py
+++ b/backend/app/domain/log.py
@@ -292,6 +292,9 @@ class LogCostSummary(BaseModel):
     """Aggregated cost summary"""
 
     request_count: int = 0
+    success_count: int = 0
+    failure_count: int = 0
+    success_rate: float = 0.0
     total_cost: float = 0.0
     input_cost: float = 0.0
     output_cost: float = 0.0
@@ -330,13 +333,27 @@ class LogCostByModel(BaseModel):
     output_tokens: int = 0
 
 
+class ModelCallStats(BaseModel):
+    """Call health stats grouped by provider and actual model"""
+
+    provider_name: str
+    model_name: str
+    request_count: int = 0
+    success_count: int = 0
+    failure_count: int = 0
+    success_rate: float = 0.0
+    avg_first_byte_time_ms: Optional[float] = None
+    max_first_byte_time_ms: Optional[float] = None
+
+
 class LogCostStatsResponse(BaseModel):
     """Cost stats response"""
 
     summary: LogCostSummary
     trend: list[LogCostTrendPoint]
     by_model: list[LogCostByModel]
-    by_model_tokens: list[LogCostByModel] = []
+    by_model_tokens: list[LogCostByModel] = Field(default_factory=list)
+    model_call_stats: list[ModelCallStats] = Field(default_factory=list)
 
 
 class ModelStats(BaseModel):

--- a/backend/app/repositories/sqlalchemy/log_repo.py
+++ b/backend/app/repositories/sqlalchemy/log_repo.py
@@ -21,6 +21,7 @@ from app.domain.log import (
     LogCostStatsResponse,
     LogCostSummary,
     LogCostTrendPoint,
+    ModelCallStats,
     ModelProviderStats,
     ModelStats,
     RequestLogCreate,
@@ -709,7 +710,22 @@ class SQLAlchemyLogRepository(LogRepository):
     async def get_cost_stats(self, query: LogCostStatsQuery) -> LogCostStatsResponse:
         # In-progress rows have no final status, usage, or cost. Counting them
         # here would incorrectly classify them as successful requests.
-        conditions = [RequestLogORM.is_completed.is_(True)]
+        # A trace can also contain failed retry-attempt rows. Dashboard stats
+        # count one client call per trace, so only the earliest (root) row is
+        # included.
+        earlier_log = aliased(RequestLogORM)
+        is_trace_root = or_(
+            RequestLogORM.trace_id.is_(None),
+            RequestLogORM.trace_id == "",
+            ~select(earlier_log.id)
+            .where(
+                earlier_log.trace_id == RequestLogORM.trace_id,
+                earlier_log.id < RequestLogORM.id,
+            )
+            .correlate(RequestLogORM)
+            .exists(),
+        )
+        conditions = [RequestLogORM.is_completed.is_(True), is_trace_root]
         tz_offset_minutes = int(query.tz_offset_minutes or 0)
 
         if query.start_time:
@@ -743,11 +759,21 @@ class SQLAlchemyLogRepository(LogRepository):
         sum_in_tokens = func.coalesce(func.sum(RequestLogORM.input_tokens), 0)
         sum_out_tokens = func.coalesce(func.sum(RequestLogORM.output_tokens), 0)
 
-        error_condition = RequestLogORM.response_status >= 400
-        sum_error = func.coalesce(func.sum(case((error_condition, 1), else_=0)), 0)
+        success_condition = and_(
+            RequestLogORM.response_status >= 200,
+            RequestLogORM.response_status < 400,
+        )
+        sum_success = func.coalesce(
+            func.sum(case((success_condition, 1), else_=0)), 0
+        )
+        sum_failure = func.coalesce(
+            func.sum(case((success_condition, 0), else_=1)), 0
+        )
 
         summary_stmt = select(
             func.count().label("request_count"),
+            sum_success.label("success_count"),
+            sum_failure.label("failure_count"),
             sum_total.label("total_cost"),
             sum_input.label("input_cost"),
             sum_output.label("output_cost"),
@@ -758,8 +784,14 @@ class SQLAlchemyLogRepository(LogRepository):
             summary_stmt = summary_stmt.where(where_clause)
 
         summary_row = (await self.session.execute(summary_stmt)).mappings().one()
+        request_count = int(summary_row["request_count"] or 0)
+        success_count = int(summary_row["success_count"] or 0)
+        failure_count = int(summary_row["failure_count"] or 0)
         summary = LogCostSummary(
-            request_count=int(summary_row["request_count"] or 0),
+            request_count=request_count,
+            success_count=success_count,
+            failure_count=failure_count,
+            success_rate=success_count / request_count if request_count > 0 else 0.0,
             total_cost=float(summary_row["total_cost"] or 0),
             input_cost=float(summary_row["input_cost"] or 0),
             output_cost=float(summary_row["output_cost"] or 0),
@@ -848,7 +880,8 @@ class SQLAlchemyLogRepository(LogRepository):
                 sum_output.label("output_cost"),
                 sum_in_tokens.label("input_tokens"),
                 sum_out_tokens.label("output_tokens"),
-                sum_error.label("error_count"),
+                sum_failure.label("error_count"),
+                sum_success.label("success_count"),
             )
             .group_by(bucket_start_utc_expr)
             .order_by(bucket_start_utc_expr)
@@ -870,10 +903,7 @@ class SQLAlchemyLogRepository(LogRepository):
                 input_tokens=int(r["input_tokens"] or 0),
                 output_tokens=int(r["output_tokens"] or 0),
                 error_count=int(r["error_count"] or 0),
-                success_count=max(
-                    0,
-                    int(r["request_count"] or 0) - int(r["error_count"] or 0),
-                ),
+                success_count=int(r["success_count"] or 0),
             )
             for r in trend_rows
         ]
@@ -940,11 +970,70 @@ class SQLAlchemyLogRepository(LogRepository):
             for r in model_tokens_rows
         ]
 
+        provider_name_expr = func.coalesce(RequestLogORM.provider_name, "-")
+        model_name_expr = func.coalesce(
+            RequestLogORM.target_model,
+            RequestLogORM.requested_model,
+            "-",
+        )
+        stream_ttfb = case(
+            (
+                and_(
+                    RequestLogORM.is_stream.is_(True),
+                    RequestLogORM.first_byte_delay_ms.isnot(None),
+                ),
+                RequestLogORM.first_byte_delay_ms,
+            )
+        )
+        model_call_stmt = (
+            select(
+                provider_name_expr.label("provider_name"),
+                model_name_expr.label("model_name"),
+                func.count().label("request_count"),
+                sum_success.label("success_count"),
+                sum_failure.label("failure_count"),
+                func.avg(stream_ttfb).label("avg_first_byte_time_ms"),
+                func.max(stream_ttfb).label("max_first_byte_time_ms"),
+            )
+            .group_by(provider_name_expr, model_name_expr)
+            .order_by(func.count().desc(), provider_name_expr, model_name_expr)
+        )
+        if where_clause is not None:
+            model_call_stmt = model_call_stmt.where(where_clause)
+        model_call_rows = (
+            (await self.session.execute(model_call_stmt)).mappings().all()
+        )
+        model_call_stats = []
+        for row in model_call_rows:
+            total = int(row["request_count"] or 0)
+            successes = int(row["success_count"] or 0)
+            model_call_stats.append(
+                ModelCallStats(
+                    provider_name=row["provider_name"] or "-",
+                    model_name=row["model_name"] or "-",
+                    request_count=total,
+                    success_count=successes,
+                    failure_count=int(row["failure_count"] or 0),
+                    success_rate=successes / total if total > 0 else 0.0,
+                    avg_first_byte_time_ms=(
+                        float(row["avg_first_byte_time_ms"])
+                        if row["avg_first_byte_time_ms"] is not None
+                        else None
+                    ),
+                    max_first_byte_time_ms=(
+                        float(row["max_first_byte_time_ms"])
+                        if row["max_first_byte_time_ms"] is not None
+                        else None
+                    ),
+                )
+            )
+
         return LogCostStatsResponse(
             summary=summary,
             trend=trend,
             by_model=by_model,
             by_model_tokens=by_model_tokens,
+            model_call_stats=model_call_stats,
         )
 
     async def get_model_stats(

--- a/backend/app/repositories/sqlalchemy/log_repo.py
+++ b/backend/app/repositories/sqlalchemy/log_repo.py
@@ -493,7 +493,6 @@ class SQLAlchemyLogRepository(LogRepository):
             .correlate(RequestLogORM)
             .exists(),
         )
-
         # Build base query with only summary columns. Pagination is deliberately
         # applied to roots before retry attempt rows are loaded.
         stmt = select(*_SUMMARY_COLUMNS)
@@ -725,33 +724,51 @@ class SQLAlchemyLogRepository(LogRepository):
             .correlate(RequestLogORM)
             .exists(),
         )
-        conditions = [RequestLogORM.is_completed.is_(True), is_trace_root]
+        later_log = aliased(RequestLogORM)
+        has_later_trace_row = and_(
+            RequestLogORM.trace_id.isnot(None),
+            RequestLogORM.trace_id != "",
+            select(later_log.id)
+            .where(
+                later_log.trace_id == RequestLogORM.trace_id,
+                later_log.id > RequestLogORM.id,
+            )
+            .correlate(RequestLogORM)
+            .exists(),
+        )
+        base_conditions = [RequestLogORM.is_completed.is_(True)]
         tz_offset_minutes = int(query.tz_offset_minutes or 0)
 
         if query.start_time:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.request_time >= to_utc_naive(query.start_time)
             )
         if query.end_time:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.request_time <= to_utc_naive(query.end_time)
             )
         if query.provider_id:
-            conditions.append(RequestLogORM.provider_id == query.provider_id)
+            base_conditions.append(RequestLogORM.provider_id == query.provider_id)
         if query.api_key_id:
-            conditions.append(RequestLogORM.api_key_id == query.api_key_id)
+            base_conditions.append(RequestLogORM.api_key_id == query.api_key_id)
         if query.api_key_name:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.api_key_name.ilike(f"%{query.api_key_name}%")
             )
         if query.user_id:
-            conditions.append(RequestLogORM.user_id.ilike(f"%{query.user_id}%"))
+            base_conditions.append(RequestLogORM.user_id.ilike(f"%{query.user_id}%"))
         if query.requested_model:
-            conditions.append(
+            base_conditions.append(
                 RequestLogORM.requested_model.ilike(f"%{query.requested_model}%")
             )
 
-        where_clause = and_(*conditions) if conditions else None
+        # Summary, trends, costs, and token usage describe client requests and
+        # therefore use one root row per trace.
+        root_where_clause = and_(*base_conditions, is_trace_root)
+        # Per-provider/model health describes actual upstream attempts. It must
+        # include failed retry rows; otherwise a later successful fallback hides
+        # the original model's 4xx/5xx failures.
+        attempt_where_clause = and_(*base_conditions)
 
         sum_total = func.coalesce(func.sum(RequestLogORM.total_cost), 0)
         sum_input = func.coalesce(func.sum(RequestLogORM.input_cost), 0)
@@ -769,6 +786,15 @@ class SQLAlchemyLogRepository(LogRepository):
         sum_failure = func.coalesce(
             func.sum(case((success_condition, 0), else_=1)), 0
         )
+        is_upstream_attempt = or_(
+            # Failed retry rows represent each actual unsuccessful upstream call.
+            ~is_trace_root,
+            # Successful attempts are stored only on the root row.
+            success_condition,
+            # Keep standalone failures that have no retry-attempt detail rows,
+            # such as model resolution or forwarding setup failures.
+            ~has_later_trace_row,
+        )
 
         summary_stmt = select(
             func.count().label("request_count"),
@@ -780,8 +806,7 @@ class SQLAlchemyLogRepository(LogRepository):
             sum_in_tokens.label("input_tokens"),
             sum_out_tokens.label("output_tokens"),
         )
-        if where_clause is not None:
-            summary_stmt = summary_stmt.where(where_clause)
+        summary_stmt = summary_stmt.where(root_where_clause)
 
         summary_row = (await self.session.execute(summary_stmt)).mappings().one()
         request_count = int(summary_row["request_count"] or 0)
@@ -886,8 +911,7 @@ class SQLAlchemyLogRepository(LogRepository):
             .group_by(bucket_start_utc_expr)
             .order_by(bucket_start_utc_expr)
         )
-        if where_clause is not None:
-            trend_stmt = trend_stmt.where(where_clause)
+        trend_stmt = trend_stmt.where(root_where_clause)
         trend_rows = (await self.session.execute(trend_stmt)).mappings().all()
         trend = [
             LogCostTrendPoint(
@@ -927,8 +951,7 @@ class SQLAlchemyLogRepository(LogRepository):
             .order_by(sum_total.desc())
             .limit(50)
         )
-        if where_clause is not None:
-            by_model_stmt = by_model_stmt.where(where_clause)
+        by_model_stmt = by_model_stmt.where(root_where_clause)
         model_rows = (await self.session.execute(by_model_stmt)).mappings().all()
         by_model = [
             LogCostByModel(
@@ -954,8 +977,7 @@ class SQLAlchemyLogRepository(LogRepository):
             .order_by((sum_in_tokens + sum_out_tokens).desc())
             .limit(50)
         )
-        if where_clause is not None:
-            by_model_tokens_stmt = by_model_tokens_stmt.where(where_clause)
+        by_model_tokens_stmt = by_model_tokens_stmt.where(root_where_clause)
         model_tokens_rows = (
             (await self.session.execute(by_model_tokens_stmt)).mappings().all()
         )
@@ -998,8 +1020,10 @@ class SQLAlchemyLogRepository(LogRepository):
             .group_by(provider_name_expr, model_name_expr)
             .order_by(func.count().desc(), provider_name_expr, model_name_expr)
         )
-        if where_clause is not None:
-            model_call_stmt = model_call_stmt.where(where_clause)
+        model_call_stmt = model_call_stmt.where(
+            attempt_where_clause,
+            is_upstream_attempt,
+        )
         model_call_rows = (
             (await self.session.execute(model_call_stmt)).mappings().all()
         )

--- a/backend/tests/unit/test_repositories/test_log_repo_stats.py
+++ b/backend/tests/unit/test_repositories/test_log_repo_stats.py
@@ -86,3 +86,109 @@ async def test_get_cost_stats_grouping(db_session):
     assert stats_prov.by_model[0].total_cost == 5.0
     assert stats_prov.by_model[1].requested_model == "target-Y"
     assert stats_prov.by_model[1].total_cost == 2.0
+
+
+@pytest.mark.asyncio
+async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
+    repo = SQLAlchemyLogRepository(db_session)
+    now = datetime.now(timezone.utc)
+
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=200,
+        first_byte_delay_ms=100,
+        is_stream=True,
+        is_completed=True,
+        trace_id="success-stream",
+    ))
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=204,
+        first_byte_delay_ms=900,
+        is_stream=False,
+        is_completed=True,
+        trace_id="success-non-stream",
+    ))
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=500,
+        first_byte_delay_ms=300,
+        is_stream=True,
+        is_completed=True,
+        trace_id="failed-with-retry",
+    ))
+    # A retry-attempt row shares the trace and must not be counted as a separate
+    # client call.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-b",
+        provider_name="provider-b",
+        response_status=502,
+        first_byte_delay_ms=800,
+        is_stream=True,
+        is_completed=True,
+        trace_id="failed-with-retry",
+        retry_count=1,
+    ))
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-c",
+        provider_name="provider-c",
+        response_status=None,
+        is_stream=True,
+        is_completed=True,
+        trace_id="missing-status",
+    ))
+    # In-progress rows are excluded from all dashboard stats.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-d",
+        provider_name="provider-d",
+        response_status=None,
+        is_stream=True,
+        is_completed=False,
+        trace_id="in-progress",
+    ))
+
+    stats = await repo.get_cost_stats(LogCostStatsQuery(
+        start_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+    ))
+
+    assert stats.summary.request_count == 4
+    assert stats.summary.success_count == 2
+    assert stats.summary.failure_count == 2
+    assert stats.summary.success_rate == 0.5
+
+    assert len(stats.model_call_stats) == 2
+    provider_a = next(
+        item for item in stats.model_call_stats
+        if item.provider_name == "provider-a"
+    )
+    assert provider_a.model_name == "model-a"
+    assert provider_a.request_count == 3
+    assert provider_a.success_count == 2
+    assert provider_a.failure_count == 1
+    assert provider_a.success_rate == pytest.approx(2 / 3)
+    assert provider_a.avg_first_byte_time_ms == 200
+    assert provider_a.max_first_byte_time_ms == 300
+
+    provider_c = next(
+        item for item in stats.model_call_stats
+        if item.provider_name == "provider-c"
+    )
+    assert provider_c.request_count == 1
+    assert provider_c.failure_count == 1
+    assert provider_c.avg_first_byte_time_ms is None
+    assert provider_c.max_first_byte_time_ms is None

--- a/backend/tests/unit/test_repositories/test_log_repo_stats.py
+++ b/backend/tests/unit/test_repositories/test_log_repo_stats.py
@@ -118,6 +118,19 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     await repo.create(RequestLogCreate(
         request_time=now,
         requested_model="chat",
+        target_model="model-b",
+        provider_name="provider-b",
+        response_status=502,
+        first_byte_delay_ms=800,
+        is_stream=True,
+        is_completed=True,
+        trace_id="failed-with-retry",
+    ))
+    # Retry-attempt rows share the trace. They must not be counted as separate
+    # client calls in the summary, but each is a real upstream model call.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
         target_model="model-a",
         provider_name="provider-a",
         response_status=500,
@@ -125,9 +138,10 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
         is_stream=True,
         is_completed=True,
         trace_id="failed-with-retry",
+        retry_count=1,
     ))
-    # A retry-attempt row shares the trace and must not be counted as a separate
-    # client call.
+    # The final failed attempt is also present in the root row. Per-model stats
+    # must count this attempt row once and exclude the duplicate root failure.
     await repo.create(RequestLogCreate(
         request_time=now,
         requested_model="chat",
@@ -138,7 +152,7 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
         is_stream=True,
         is_completed=True,
         trace_id="failed-with-retry",
-        retry_count=1,
+        retry_count=2,
     ))
     await repo.create(RequestLogCreate(
         request_time=now,
@@ -171,7 +185,7 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     assert stats.summary.failure_count == 2
     assert stats.summary.success_rate == 0.5
 
-    assert len(stats.model_call_stats) == 2
+    assert len(stats.model_call_stats) == 3
     provider_a = next(
         item for item in stats.model_call_stats
         if item.provider_name == "provider-a"
@@ -184,6 +198,18 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     assert provider_a.avg_first_byte_time_ms == 200
     assert provider_a.max_first_byte_time_ms == 300
 
+    provider_b = next(
+        item for item in stats.model_call_stats
+        if item.provider_name == "provider-b"
+    )
+    assert provider_b.model_name == "model-b"
+    assert provider_b.request_count == 1
+    assert provider_b.success_count == 0
+    assert provider_b.failure_count == 1
+    assert provider_b.success_rate == 0
+    assert provider_b.avg_first_byte_time_ms == 800
+    assert provider_b.max_first_byte_time_ms == 800
+
     provider_c = next(
         item for item in stats.model_call_stats
         if item.provider_name == "provider-c"
@@ -192,3 +218,55 @@ async def test_get_cost_stats_call_health_and_stream_ttfb(db_session):
     assert provider_c.failure_count == 1
     assert provider_c.avg_first_byte_time_ms is None
     assert provider_c.max_first_byte_time_ms is None
+
+
+@pytest.mark.asyncio
+async def test_model_call_stats_keep_failed_attempt_before_successful_fallback(db_session):
+    repo = SQLAlchemyLogRepository(db_session)
+    now = datetime.now(timezone.utc)
+
+    # The root row contains the final successful fallback result.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-b",
+        provider_name="provider-b",
+        response_status=200,
+        first_byte_delay_ms=120,
+        is_stream=True,
+        is_completed=True,
+        trace_id="fallback-success",
+    ))
+    # The failed provider attempt is written as another row under the same trace.
+    await repo.create(RequestLogCreate(
+        request_time=now,
+        requested_model="chat",
+        target_model="model-a",
+        provider_name="provider-a",
+        response_status=500,
+        first_byte_delay_ms=450,
+        is_stream=True,
+        is_completed=True,
+        trace_id="fallback-success",
+        retry_count=1,
+    ))
+
+    stats = await repo.get_cost_stats(LogCostStatsQuery(
+        start_time=datetime(2000, 1, 1, tzinfo=timezone.utc),
+    ))
+
+    # One client request ultimately succeeded.
+    assert stats.summary.request_count == 1
+    assert stats.summary.success_count == 1
+    assert stats.summary.failure_count == 0
+
+    by_provider = {
+        item.provider_name: item
+        for item in stats.model_call_stats
+    }
+    assert by_provider["provider-a"].success_count == 0
+    assert by_provider["provider-a"].failure_count == 1
+    assert by_provider["provider-a"].success_rate == 0
+    assert by_provider["provider-b"].success_count == 1
+    assert by_provider["provider-b"].failure_count == 0
+    assert by_provider["provider-b"].success_rate == 1

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -89,6 +89,22 @@
   "home": {
     "title": "LLM Gateway",
     "description": "Model Routing & Proxy Service Management System",
+    "dashboard": {
+      "title": "Call health overview",
+      "description": "Review call reliability for the current filters and locate provider or model issues.",
+      "totalCalls": "Total calls",
+      "successfulCalls": "Successful",
+      "failedCalls": "Failed",
+      "overallSuccessRate": "Overall success rate",
+      "modelStatsTitle": "Calls by model",
+      "provider": "Provider",
+      "model": "Model",
+      "successRate": "Success rate",
+      "averageLatency": "Average latency",
+      "maximumLatency": "Maximum latency",
+      "latencyHint": "Latency uses time to first byte (TTFB) from streaming requests only.",
+      "noData": "No completed calls in this range"
+    },
     "cards": {
       "providersTitle": "Provider Management",
       "providersDescription": "Manage upstream AI providers, configure base URLs and API keys",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -89,6 +89,22 @@
   "home": {
     "title": "LLM Gateway",
     "description": "模型路由与代理服务管理系统",
+    "dashboard": {
+      "title": "调用健康概览",
+      "description": "快速查看当前筛选范围内的调用稳定性，并定位供应商或模型异常。",
+      "totalCalls": "总调用次数",
+      "successfulCalls": "成功",
+      "failedCalls": "失败",
+      "overallSuccessRate": "整体成功率",
+      "modelStatsTitle": "各模型调用统计",
+      "provider": "供应商",
+      "model": "模型",
+      "successRate": "成功率",
+      "averageLatency": "平均延迟",
+      "maximumLatency": "最大延迟",
+      "latencyHint": "延迟仅统计流式请求的首字节时间（TTFB）。",
+      "noData": "当前范围内暂无已完成的调用"
+    },
     "cards": {
       "providersTitle": "供应商管理",
       "providersDescription": "管理上游 AI 供应商，配置基础 URL 和 API Key",

--- a/frontend/src/components/home/HomeCallStats.tsx
+++ b/frontend/src/components/home/HomeCallStats.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Activity, CheckCircle2, Gauge, XCircle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { LogCostStatsResponse } from '@/types';
+import { formatDuration, formatNumber } from '@/lib/utils';
+
+interface HomeCallStatsProps {
+  stats: LogCostStatsResponse;
+}
+
+function formatRate(rate: number) {
+  return `${(Math.max(0, Math.min(1, rate)) * 100).toFixed(1)}%`;
+}
+
+export function HomeCallStats({ stats }: HomeCallStatsProps) {
+  const t = useTranslations('home.dashboard');
+  const { summary, model_call_stats: modelStats } = stats;
+  const successRate = Math.max(0, Math.min(1, summary.success_rate));
+
+  const metrics = [
+    {
+      label: t('totalCalls'),
+      value: formatNumber(summary.request_count),
+      icon: Activity,
+      className: 'text-sky-600 dark:text-sky-400',
+    },
+    {
+      label: t('successfulCalls'),
+      value: formatNumber(summary.success_count),
+      icon: CheckCircle2,
+      className: 'text-emerald-600 dark:text-emerald-400',
+    },
+    {
+      label: t('failedCalls'),
+      value: formatNumber(summary.failure_count),
+      icon: XCircle,
+      className: 'text-rose-600 dark:text-rose-400',
+    },
+    {
+      label: t('overallSuccessRate'),
+      value: formatRate(successRate),
+      icon: Gauge,
+      className: 'text-violet-600 dark:text-violet-400',
+      rate: successRate,
+    },
+  ];
+
+  return (
+    <section className="space-y-4" aria-labelledby="call-health-title">
+      <div>
+        <h2 id="call-health-title" className="text-base font-semibold">
+          {t('title')}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('description')}</p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => {
+          const Icon = metric.icon;
+          return (
+            <div
+              key={metric.label}
+              className="relative overflow-hidden rounded-lg border bg-card px-4 py-3 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-medium text-muted-foreground">
+                    {metric.label}
+                  </div>
+                  <div className="mt-2 font-mono text-2xl font-semibold tabular-nums">
+                    {metric.value}
+                  </div>
+                </div>
+                <Icon className={`h-5 w-5 ${metric.className}`} aria-hidden="true" />
+              </div>
+              {metric.rate !== undefined ? (
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-violet-500 transition-[width]"
+                    style={{ width: `${metric.rate * 100}%` }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">{t('modelStatsTitle')}</CardTitle>
+          <p className="text-sm text-muted-foreground">{t('latencyHint')}</p>
+        </CardHeader>
+        <CardContent>
+          {modelStats.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              {t('noData')}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('provider')}</TableHead>
+                  <TableHead>{t('model')}</TableHead>
+                  <TableHead className="text-right">{t('totalCalls')}</TableHead>
+                  <TableHead className="text-right">{t('successfulCalls')}</TableHead>
+                  <TableHead className="text-right">{t('failedCalls')}</TableHead>
+                  <TableHead className="text-right">{t('successRate')}</TableHead>
+                  <TableHead className="text-right">{t('averageLatency')}</TableHead>
+                  <TableHead className="text-right">{t('maximumLatency')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {modelStats.map((item) => (
+                  <TableRow key={`${item.provider_name}:${item.model_name}`}>
+                    <TableCell className="font-medium">{item.provider_name}</TableCell>
+                    <TableCell className="max-w-[260px] font-mono text-xs">
+                      <span className="block truncate" title={item.model_name}>
+                        {item.model_name}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatNumber(item.request_count)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums text-emerald-600 dark:text-emerald-400">
+                      {formatNumber(item.success_count)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums text-rose-600 dark:text-rose-400">
+                      {formatNumber(item.failure_count)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatRate(item.success_rate)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatDuration(item.avg_first_byte_time_ms)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatDuration(item.max_first_byte_time_ms)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/components/home/HomeCostStats.tsx
+++ b/frontend/src/components/home/HomeCostStats.tsx
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Input } from '@/components/ui/input';
 import { useTranslations } from 'next-intl';
 import { useApiKeys } from '@/lib/hooks';
+import { HomeCallStats } from './HomeCallStats';
 
 type RangePreset =
   | '1h'
@@ -313,6 +314,7 @@ export function HomeCostStats() {
       bucket={displayRange.bucket}
       bucketMinutes={displayRange.bucket_minutes}
       maxBars={MAX_TREND_BARS}
+      beforeCharts={data ? <HomeCallStats stats={data} /> : null}
       modelStatsControls={
         <div className="flex items-center gap-2">
            <Select

--- a/frontend/src/components/home/HomeCostStats.tsx
+++ b/frontend/src/components/home/HomeCostStats.tsx
@@ -314,7 +314,7 @@ export function HomeCostStats() {
       bucket={displayRange.bucket}
       bucketMinutes={displayRange.bucket_minutes}
       maxBars={MAX_TREND_BARS}
-      beforeCharts={data ? <HomeCallStats stats={data} /> : null}
+      afterContent={data ? <HomeCallStats stats={data} /> : null}
       modelStatsControls={
         <div className="flex items-center gap-2">
            <Select

--- a/frontend/src/components/logs/CostStats.tsx
+++ b/frontend/src/components/logs/CostStats.tsx
@@ -34,6 +34,7 @@ interface CostStatsProps {
   refreshing?: boolean;
   headerActions?: React.ReactNode;
   headerExtras?: React.ReactNode;
+  beforeCharts?: React.ReactNode;
   modelStatsControls?: React.ReactNode;
   rangeLabel?: string;
   rangeDays?: number;
@@ -448,6 +449,7 @@ export function CostStats({
   refreshing,
   headerActions,
   headerExtras,
+  beforeCharts,
   rangeLabel,
   rangeDays = 1,
   rangeStart,
@@ -674,6 +676,8 @@ export function CostStats({
 
         {!loading && stats && (
           <>
+            {beforeCharts}
+
             <div className="grid gap-4 lg:grid-cols-3">
               <TrendCard
                 title={t("costStats.spend")}

--- a/frontend/src/components/logs/CostStats.tsx
+++ b/frontend/src/components/logs/CostStats.tsx
@@ -34,7 +34,7 @@ interface CostStatsProps {
   refreshing?: boolean;
   headerActions?: React.ReactNode;
   headerExtras?: React.ReactNode;
-  beforeCharts?: React.ReactNode;
+  afterContent?: React.ReactNode;
   modelStatsControls?: React.ReactNode;
   rangeLabel?: string;
   rangeDays?: number;
@@ -449,7 +449,7 @@ export function CostStats({
   refreshing,
   headerActions,
   headerExtras,
-  beforeCharts,
+  afterContent,
   rangeLabel,
   rangeDays = 1,
   rangeStart,
@@ -676,8 +676,6 @@ export function CostStats({
 
         {!loading && stats && (
           <>
-            {beforeCharts}
-
             <div className="grid gap-4 lg:grid-cols-3">
               <TrendCard
                 title={t("costStats.spend")}
@@ -909,6 +907,8 @@ export function CostStats({
                 </div>
               </div>
             </div>
+
+            {afterContent}
           </>
         )}
       </CardContent>

--- a/frontend/src/types/log.ts
+++ b/frontend/src/types/log.ts
@@ -146,6 +146,9 @@ export interface LogQueryParams {
 
 export interface LogCostSummary {
   request_count: number;
+  success_count: number;
+  failure_count: number;
+  success_rate: number;
   total_cost: number;
   input_cost: number;
   output_cost: number;
@@ -173,9 +176,21 @@ export interface LogCostByModel {
   output_tokens: number;
 }
 
+export interface ModelCallStats {
+  provider_name: string;
+  model_name: string;
+  request_count: number;
+  success_count: number;
+  failure_count: number;
+  success_rate: number;
+  avg_first_byte_time_ms: number | null;
+  max_first_byte_time_ms: number | null;
+}
+
 export interface LogCostStatsResponse {
   summary: LogCostSummary;
   trend: LogCostTrendPoint[];
   by_model: LogCostByModel[];
   by_model_tokens: LogCostByModel[];
+  model_call_stats: ModelCallStats[];
 }


### PR DESCRIPTION
## Summary

Introduces per-provider/per-model call health statistics on the dashboard and refines how stats are computed so that client-facing metrics and upstream-attempt metrics are no longer conflated.

## Changes

### Backend
- **New domain model** `ModelCallStats`: provider name, model name, request/success/failure counts, success rate, and average/max first-byte time (TTFB) for streaming responses.
- **Extended `LogCostSummary`** with `success_count`, `failure_count`, and `success_rate`.
- **Extended `LogCostStatsResponse`** with a new `model_call_stats` list (and switched `by_model_tokens` to use `Field(default_factory=list)`).
- **Refactored `get_cost_stats`** to distinguish two scopes:
  - **Root rows** (earliest row of each trace, or standalone logs) drive summary, trend, cost, and token-usage stats — representing one client call per trace.
  - **Upstream attempts** (failed retry rows + successful root rows + standalone failures) drive the new per-model health stats, so failed retries that were masked by a later successful fallback are now correctly counted against the originally attempted model.
- Trend now derives `success_count` directly instead of subtracting errors.

### Frontend
- New `HomeCallStats.tsx` component rendering per-model health (requests, success rate, success/failure counts, avg/max TTFB).
- Updated `HomeCostStats.tsx`, `CostStats.tsx`, and log types accordingly.
- Added i18n entries for both `en` and `zh`.

### Tests
- Added `test_log_repo_stats.py` covering the new stats behavior.

## Why
Previously, dashboard stats counted only root rows, which meant failed upstream retry attempts were hidden whenever a fallback succeeded. This PR surfaces true per-model health while keeping client-facing aggregates consistent.