### PR TITLE
fix: use provider default max_tokens instead of hard-coded 4096

### DIFF
--- a/backend/app/common/protocol/base.py
+++ b/backend/app/common/protocol/base.py
@@ -13,6 +13,9 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 
+DEFAULT_MAX_TOKENS = 16384
+
+
 class Protocol(str, Enum):
     """Supported API protocols."""
     OPENAI = "openai"

--- a/backend/app/common/protocol/converters.py
+++ b/backend/app/common/protocol/converters.py
@@ -22,6 +22,7 @@ from app.common.usage_extractor import extract_usage_details
 
 from .base import (
     ConversionResult,
+    DEFAULT_MAX_TOKENS,
     IRequestConverter,
     IResponseConverter,
     IStreamConverter,
@@ -1485,7 +1486,7 @@ class SDKRequestConverter(IRequestConverter):
 
             # Handle max_tokens for Anthropic target
             if self._target == Protocol.ANTHROPIC:
-                body = self._ensure_max_tokens_for_anthropic(body)
+                body = self._ensure_max_tokens_for_anthropic(body, options=options)
 
             # Remove stream_options and include_usage when streaming to OpenAI or OpenAI Responses
             # These parameters are not supported by all providers and can cause errors
@@ -1537,7 +1538,12 @@ class SDKRequestConverter(IRequestConverter):
                 target_protocol=self._target.value,
             ) from e
 
-    def _ensure_max_tokens_for_anthropic(self, body: Dict[str, Any]) -> Dict[str, Any]:
+    def _ensure_max_tokens_for_anthropic(
+        self,
+        body: Dict[str, Any],
+        *,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """
         Ensure max_tokens is set when converting to Anthropic protocol.
 
@@ -1550,25 +1556,39 @@ class SDKRequestConverter(IRequestConverter):
         so the SDK decoder can read it properly.
         """
         body = copy.deepcopy(body)
+        default_parameters = (options or {}).get("default_parameters")
+        configured_max_tokens = None
+        if isinstance(default_parameters, dict):
+            configured_max_tokens = default_parameters.get("max_tokens")
+
+        # The SDK conversion happens after this method. Put the provider default
+        # on the source field that the SDK decoder understands; otherwise the
+        # hard-coded fallback below makes the request look explicit and prevents
+        # the configured default from taking effect.
+        fallback_max_tokens = (
+            configured_max_tokens
+            if configured_max_tokens is not None
+            else DEFAULT_MAX_TOKENS
+        )
 
         if self._source == Protocol.OPENAI_RESPONSES:
             # For OpenAI Responses, ensure max_output_tokens is set
             if body.get("max_output_tokens") is None:
-                body["max_output_tokens"] = 4096
+                body["max_output_tokens"] = fallback_max_tokens
         elif self._source == Protocol.OPENAI:
             # For OpenAI Chat, ensure max_tokens or max_completion_tokens is set
             if (
                 body.get("max_tokens") is None
                 and body.get("max_completion_tokens") is None
             ):
-                body["max_tokens"] = 4096
+                body["max_tokens"] = fallback_max_tokens
         elif self._source == Protocol.ANTHROPIC:
             # For Anthropic source, ensure max_tokens is set
             if body.get("max_tokens") is None:
                 if body.get("max_completion_tokens") is not None:
                     body["max_tokens"] = body["max_completion_tokens"]
                 else:
-                    body["max_tokens"] = 4096
+                    body["max_tokens"] = fallback_max_tokens
 
         return body
 

--- a/backend/app/common/protocol/registry.py
+++ b/backend/app/common/protocol/registry.py
@@ -17,6 +17,7 @@ from app.common.reasoning import (
 
 from .base import (
     ConversionResult,
+    DEFAULT_MAX_TOKENS,
     IProtocolAdapter,
     IRequestConverter,
     IResponseConverter,
@@ -375,7 +376,7 @@ class ProtocolConverterManager:
                 if new_body.get("max_completion_tokens") is not None:
                     new_body["max_tokens"] = new_body["max_completion_tokens"]
                 else:
-                    new_body["max_tokens"] = 4096
+                    new_body["max_tokens"] = DEFAULT_MAX_TOKENS
 
         return ConversionResult(path=path, body=new_body)
 

--- a/backend/tests/unit/test_common/test_protocol_conversion.py
+++ b/backend/tests/unit/test_common/test_protocol_conversion.py
@@ -662,9 +662,61 @@ def test_convert_request_openai_responses_to_anthropic_without_max_output_tokens
 
     assert path == "/v1/messages"
     assert out_body["model"] == "claude-3-5-sonnet"
-    # Default max_tokens should be 4096
-    assert out_body["max_tokens"] == 4096
+    # Global default max_tokens should be 16384
+    assert out_body["max_tokens"] == 16384
     assert isinstance(out_body.get("messages"), list)
+
+
+def test_convert_request_openai_responses_to_anthropic_uses_provider_default_max_tokens():
+    path, out_body = convert_request_for_supplier(
+        request_protocol="openai_responses",
+        supplier_protocol="anthropic",
+        path="/v1/responses",
+        body={
+            "model": "any",
+            "input": "Hello, how are you?",
+        },
+        target_model="claude-3-5-sonnet",
+        options={"default_parameters": {"max_tokens": 16384}},
+    )
+
+    assert path == "/v1/messages"
+    assert out_body["max_tokens"] == 16384
+
+
+def test_convert_request_openai_to_anthropic_uses_provider_default_max_tokens():
+    path, out_body = convert_request_for_supplier(
+        request_protocol="openai",
+        supplier_protocol="anthropic",
+        path="/v1/chat/completions",
+        body={
+            "model": "any",
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+        target_model="claude-3-5-sonnet",
+        options={"default_parameters": {"max_tokens": 16384}},
+    )
+
+    assert path == "/v1/messages"
+    assert out_body["max_tokens"] == 16384
+
+
+def test_convert_request_openai_to_anthropic_explicit_max_tokens_wins_over_default():
+    path, out_body = convert_request_for_supplier(
+        request_protocol="openai",
+        supplier_protocol="anthropic",
+        path="/v1/chat/completions",
+        body={
+            "model": "any",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 2048,
+        },
+        target_model="claude-3-5-sonnet",
+        options={"default_parameters": {"max_tokens": 16384}},
+    )
+
+    assert path == "/v1/messages"
+    assert out_body["max_tokens"] == 2048
 
 
 def test_convert_request_openai_responses_to_openai_accepts_string_tool_choice():
@@ -743,7 +795,7 @@ def test_convert_request_anthropic_to_anthropic_injects_default_max_tokens():
 
     assert path == "/v1/messages"
     assert out_body["model"] == "claude-3-5-sonnet"
-    assert out_body["max_tokens"] == 4096
+    assert out_body["max_tokens"] == 16384
 
 
 def test_convert_request_anthropic_to_anthropic_uses_provider_default_max_tokens():

--- a/frontend/src/components/providers/ProviderForm.tsx
+++ b/frontend/src/components/providers/ProviderForm.tsx
@@ -266,7 +266,7 @@ export function ProviderForm({
     if (defaultParameters.length > 0) return;
     if (protocol !== 'anthropic') return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setDefaultParameters([{ key: 'max_tokens', value: '4096' }]);
+    setDefaultParameters([{ key: 'max_tokens', value: '16384' }]);
   }, [provider, protocol, defaultParameters.length]);
 
   // Auto-fill base_url when protocol changes — only if user hasn't manually customised it.


### PR DESCRIPTION
## Summary

Fix the default `max_tokens` handling so that when a user has configured provider default parameters, those values are honored on Anthropic conversions instead of always falling back to a hard-coded 4096. Also introduces a shared `DEFAULT_MAX_TOKENS = 16384` constant for the system-level fallback.

## Changes

- **`backend/app/common/protocol/base.py`**: Add a module-level `DEFAULT_MAX_TOKENS = 16384` constant and import it from `converters.py` and `registry.py`.
- **`backend/app/common/protocol/converters.py`**: `_ensure_max_tokens_for_anthropic` now accepts the conversion `options` and reads `default_parameters.max_tokens` from them. If configured, that value is used; otherwise the global `DEFAULT_MAX_TOKENS` (16384) is used. Previously 4096 was hard-coded regardless of provider configuration.
- **`backend/app/common/protocol/registry.py`**: Replace the hard-coded `4096` Anthropic fallback with `DEFAULT_MAX_TOKENS`.
- **`backend/tests/unit/test_common/test_protocol_conversion.py`**:
  - Update existing assertions from 4096 → 16384.
  - Add new tests covering: provider default `max_tokens` applied when converting `openai_responses` → `anthropic` and `openai` → `anthropic`, and explicit request `max_tokens` taking precedence over the configured default.
- **`frontend/src/components/providers/ProviderForm.tsx`**: Auto-populated `max_tokens` default for Anthropic providers changed from 4096 to 16384 to match the backend.

## Motivation

The hard-coded 4096 fallback made Anthropic requests look "explicit" to the SDK decoder, which prevented the user-configured `default_parameters.max_tokens` from taking effect. This change ensures provider-level defaults flow through correctly while explicit request values still win.