### PR TITLE
GUL-31: 修复 Anthropic 工具参数对象校验

### DIFF
--- a/backend/tests/unit/test_common/test_protocol_conversion.py
+++ b/backend/tests/unit/test_common/test_protocol_conversion.py
@@ -475,6 +475,40 @@ async def test_convert_request_openai_to_anthropic_preserves_tool_calls_and_user
     assert tool_use_blocks[0].get("id") == "call_1"
 
 
+def test_convert_request_openai_to_anthropic_sanitizes_non_object_tool_input():
+    """Malformed tool history must still produce Anthropic-compatible input."""
+    _, out_body = convert_request_for_supplier(
+        request_protocol="openai",
+        supplier_protocol="anthropic",
+        path="/v1/chat/completions",
+        body={
+            "model": "any",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "tool_invalid",
+                            "type": "function",
+                            "function": {
+                                "name": "run_shell_command",
+                                "arguments": json.dumps(
+                                    '{}{"command":"brew install can1357/tap/omp"}'
+                                ),
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+        target_model="MiniMax-M3",
+    )
+
+    tool_use = out_body["messages"][0]["content"][0]
+    assert tool_use["type"] == "tool_use"
+    assert tool_use["input"] == {}
+
+
 @pytest.mark.asyncio
 async def test_convert_request_anthropic_to_openai_preserves_tools():
     path, out_body = convert_request_for_supplier(

--- a/llm_api_converter/api_protocol_converter/converters/openai_chat.py
+++ b/llm_api_converter/api_protocol_converter/converters/openai_chat.py
@@ -573,10 +573,11 @@ class OpenAIChatDecoder:
         return "application/octet-stream", data_url
 
     def _parse_json_safely(self, json_str: str) -> Dict[str, Any]:
-        """Safely parse JSON string."""
+        """Parse tool arguments, falling back when they are not a JSON object."""
         try:
-            return json.loads(json_str) if json_str else {}
-        except json.JSONDecodeError:
+            value = json.loads(json_str) if json_str else {}
+            return value if isinstance(value, dict) else {}
+        except (json.JSONDecodeError, TypeError):
             return {}
 
 

--- a/llm_api_converter/api_protocol_converter/converters/openai_responses.py
+++ b/llm_api_converter/api_protocol_converter/converters/openai_responses.py
@@ -581,10 +581,11 @@ class OpenAIResponsesDecoder:
         return "application/octet-stream", data_url
 
     def _parse_json_safely(self, json_str: str) -> Dict[str, Any]:
-        """Safely parse JSON string."""
+        """Parse tool arguments, falling back when they are not a JSON object."""
         try:
-            return json.loads(json_str) if json_str else {}
-        except json.JSONDecodeError:
+            value = json.loads(json_str) if json_str else {}
+            return value if isinstance(value, dict) else {}
+        except (json.JSONDecodeError, TypeError):
             return {}
 
 

--- a/llm_api_converter/tests/test_converters.py
+++ b/llm_api_converter/tests/test_converters.py
@@ -425,6 +425,31 @@ class TestOpenAIResponsesToAnthropicMessages:
 
         assert result["system"] == "You are a helpful assistant."
 
+    @pytest.mark.parametrize(
+        "arguments",
+        [json.dumps('{}{"command":"brew install omp"}'), "{invalid", ["invalid"]],
+    )
+    def test_request_with_invalid_tool_arguments_uses_empty_input(self, arguments):
+        """Anthropic tool_use.input must be an object even for invalid history."""
+        result = openai_responses_to_anthropic_messages_request(
+            {
+                "model": "gpt-4o",
+                "input": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_invalid",
+                        "name": "run_shell_command",
+                        "arguments": arguments,
+                    }
+                ],
+                "max_output_tokens": 100,
+            }
+        )
+
+        tool_use = result["messages"][0]["content"][0]
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["input"] == {}
+
     def test_simple_response(self):
         """Test simple response conversion."""
         result = openai_responses_to_anthropic_messages_response(
@@ -855,6 +880,38 @@ class TestEdgeCases:
 
         tool_uses = [c for c in result["content"] if c["type"] == "tool_use"]
         assert len(tool_uses) == 2
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [json.dumps('{}{"command":"brew install omp"}'), "{invalid", ["invalid"]],
+    )
+    def test_openai_chat_invalid_tool_arguments_uses_empty_input(self, arguments):
+        """A JSON string value must not leak into Anthropic tool_use.input."""
+        request = {
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_invalid",
+                            "type": "function",
+                            "function": {
+                                "name": "run_shell_command",
+                                "arguments": arguments,
+                            },
+                        }
+                    ],
+                }
+            ],
+            "max_tokens": 100,
+        }
+
+        result = openai_chat_to_anthropic_messages_request(request)
+
+        tool_use = result["messages"][0]["content"][0]
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["input"] == {}
 
     def test_base64_image_conversion(self):
         """Test conversion of base64 encoded images."""


### PR DESCRIPTION
## Summary
- 校验 OpenAI Chat/Responses 工具参数解析结果必须为 JSON 对象
- 对畸形 JSON、非对象 JSON 和错误类型统一降级为空对象，避免生成非法 Anthropic `tool_use.input`
- 补充网关级与转换器级回归测试

## Tests
- `cd backend && uv run pytest -q` (734 passed)
- `cd llm_api_converter && uv run --extra dev pytest -q` (59 passed)
- `git diff --check`

Closes GUL-31