### PR TITLE
GUL-45: 支持模型强制关闭思考模式

### DIFF
--- a/backend/app/common/reasoning.py
+++ b/backend/app/common/reasoning.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+from app.common.errors import ServiceError
+from app.common.provider_protocols import normalize_frontend_protocol
+
 OPENAI_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 ANTHROPIC_THINKING_TYPES = {"enabled", "disabled", "adaptive"}
 ANTHROPIC_EFFORTS = {"low", "medium", "high", "max"}
@@ -23,6 +26,13 @@ _ANTHROPIC_TO_OPENAI_EFFORT = {
     "high": "high",
     "max": "xhigh",
 }
+
+_GEMINI_MINIMAL_THINKING_PREFIXES = (
+    "gemini-3-flash",
+    "gemini-3.1-flash-lite",
+    "gemini-3.5-flash",
+    "gemini-3.6-flash",
+)
 
 
 def _clean_openai_effort(value: Any) -> str | None:
@@ -203,4 +213,95 @@ def normalize_reasoning_for_dashscope(
     if thinking_enabled is not None:
         out["enable_thinking"] = thinking_enabled
 
+    return out
+
+
+def _remove_cross_protocol_reasoning_fields(out: dict[str, Any]) -> None:
+    """Remove controls that belong to a different upstream protocol."""
+    out.pop("reasoning", None)
+    out.pop("thinking", None)
+    out.pop("enable_thinking", None)
+    output_config = out.get("output_config")
+    if isinstance(output_config, dict):
+        output_config = copy.deepcopy(output_config)
+        output_config.pop("effort", None)
+        if output_config:
+            out["output_config"] = output_config
+        else:
+            out.pop("output_config", None)
+    else:
+        out.pop("output_config", None)
+
+
+def _force_disable_gemini_thinking(
+    out: dict[str, Any], target_model: str
+) -> dict[str, Any]:
+    model = (target_model or "").lower().removeprefix("models/")
+    generation_config = out.get("generationConfig")
+    if not isinstance(generation_config, dict):
+        generation_config = {}
+    else:
+        generation_config = copy.deepcopy(generation_config)
+
+    # Models before the 2.5 thinking family do not need an explicit control.
+    if model.startswith(("gemini-1.", "gemini-2.0")):
+        generation_config.pop("thinkingConfig", None)
+    elif model.startswith("gemini-2.5-flash"):
+        generation_config["thinkingConfig"] = {
+            "includeThoughts": False,
+            "thinkingBudget": 0,
+        }
+    elif model.startswith(_GEMINI_MINIMAL_THINKING_PREFIXES):
+        generation_config["thinkingConfig"] = {
+            "includeThoughts": False,
+            "thinkingLevel": "minimal",
+        }
+    else:
+        raise ServiceError(
+            message=(
+                f"Provider model '{target_model}' does not support disabling "
+                "Gemini thinking"
+            ),
+            code="thinking_disable_unsupported",
+        )
+
+    if generation_config:
+        out["generationConfig"] = generation_config
+    else:
+        out.pop("generationConfig", None)
+    return out
+
+
+def force_disable_reasoning_for_supplier(
+    body: dict[str, Any],
+    *,
+    supplier_protocol: str,
+    target_model: str,
+) -> dict[str, Any]:
+    """Apply the supplier's strongest supported no-thinking request control.
+
+    This is intentionally a final override. Callers must invoke it after normal
+    protocol conversion, provider defaults, and request-conversion hooks.
+    """
+    out = copy.deepcopy(body)
+    protocol = normalize_frontend_protocol(supplier_protocol)
+
+    if protocol == "gemini":
+        _remove_cross_protocol_reasoning_fields(out)
+        return _force_disable_gemini_thinking(out, target_model)
+
+    _remove_cross_protocol_reasoning_fields(out)
+    if protocol in {"deepseek", "zhipu", "moonshot", "ark"}:
+        out["thinking"] = {"type": "disabled"}
+    elif protocol == "aliyun":
+        out["enable_thinking"] = False
+    elif protocol == "anthropic":
+        out["thinking"] = {"type": "disabled"}
+    elif protocol in {"openai", "openai_responses"}:
+        out["reasoning"] = {"effort": "none"}
+    else:
+        raise ServiceError(
+            message=f"Provider protocol '{supplier_protocol}' cannot disable thinking",
+            code="thinking_disable_unsupported",
+        )
     return out

--- a/backend/app/common/reasoning.py
+++ b/backend/app/common/reasoning.py
@@ -243,8 +243,11 @@ def _force_disable_gemini_thinking(
     else:
         generation_config = copy.deepcopy(generation_config)
 
-    # Models before the 2.5 thinking family do not need an explicit control.
-    if model.startswith(("gemini-1.", "gemini-2.0")):
+    # Non-thinking models before the 2.5 family do not need an explicit
+    # control. Do not silently treat the old 2.0 Thinking experimental models
+    # as disabled: they have no documented off control, so they must fail
+    # closed like every other unsupported thinking model.
+    if model.startswith(("gemini-1.", "gemini-2.0")) and "thinking" not in model:
         generation_config.pop("thinkingConfig", None)
     elif model.startswith("gemini-2.5-flash"):
         generation_config["thinkingConfig"] = {

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -177,6 +177,10 @@ class ModelMapping(Base):
     )
     # Is Active
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Force provider-specific thinking/reasoning controls off for this model.
+    disable_thinking: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
     # Creation Time
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=utc_now_naive, nullable=False

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -148,6 +148,7 @@ def _run_migrations(sync_conn) -> None:
             "cached_input_price": "cached_input_price NUMERIC(12,4)",
             "cached_output_price": "cached_output_price NUMERIC(12,4)",
             "cache_creation_input_price": "cache_creation_input_price NUMERIC(12,4)",
+            "disable_thinking": "disable_thinking BOOLEAN NOT NULL DEFAULT FALSE",
         },
     )
     if "model_mappings" in table_names:

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -60,6 +60,8 @@ class ModelMappingCreate(ModelMappingBase):
     capabilities: Optional[dict[str, Any]] = Field(None, description="Model Capabilities")
     # Is Active
     is_active: bool = Field(True, description="Is Active")
+    # Force all requests routed through this model to disable reasoning/thinking.
+    disable_thinking: bool = Field(False, description="Force Disable Thinking")
     # Default pricing (USD per 1,000,000 tokens)
     input_price: Optional[float] = Field(None, description="Input price ($/1M tokens)")
     output_price: Optional[float] = Field(None, description="Output price ($/1M tokens)")
@@ -106,6 +108,7 @@ class ModelMappingUpdate(BaseModel):
     matching_rules: Optional[dict[str, Any]] = None
     capabilities: Optional[dict[str, Any]] = None
     is_active: Optional[bool] = None
+    disable_thinking: Optional[bool] = None
     input_price: Optional[float] = None
     output_price: Optional[float] = None
     billing_mode: Optional[BillingMode] = None
@@ -123,6 +126,7 @@ class ModelMapping(ModelMappingBase):
 
     capabilities: Optional[dict[str, Any]] = None
     is_active: bool = True
+    disable_thinking: bool = False
     input_price: Optional[float] = None
     output_price: Optional[float] = None
     billing_mode: Optional[BillingMode] = None

--- a/backend/app/repositories/sqlalchemy/model_repo.py
+++ b/backend/app/repositories/sqlalchemy/model_repo.py
@@ -6,7 +6,7 @@ Provides concrete database operation implementation for Model Mappings and Model
 
 from typing import Optional
 
-from sqlalchemy import func, select, delete, or_
+from sqlalchemy import and_, exists, func, select, delete, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -79,6 +79,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             matching_rules=entity.matching_rules,
             capabilities=entity.capabilities,
             is_active=entity.is_active,
+            disable_thinking=entity.disable_thinking,
             input_price=float(entity.input_price) if entity.input_price is not None else None,
             output_price=float(entity.output_price) if entity.output_price is not None else None,
             billing_mode=entity.billing_mode,
@@ -146,6 +147,7 @@ class SQLAlchemyModelRepository(ModelRepository):
             matching_rules=data.matching_rules,
             capabilities=data.capabilities,
             is_active=data.is_active,
+            disable_thinking=data.disable_thinking,
             input_price=data.input_price,
             output_price=data.output_price,
             billing_mode=data.billing_mode,
@@ -194,7 +196,29 @@ class SQLAlchemyModelRepository(ModelRepository):
         conditions = []
         
         if is_active is not None:
-            conditions.append(ModelMappingORM.is_active == is_active)
+            target_mapping = ModelMappingORM.__table__.alias("alias_active_target")
+            alias_target_has_status = exists(
+                select(1).where(
+                    target_mapping.c.requested_model
+                    == ModelMappingORM.alias_target_model,
+                    target_mapping.c.is_active == is_active,
+                )
+            )
+            conditions.append(
+                or_(
+                    and_(
+                        or_(
+                            ModelMappingORM.model_type.is_(None),
+                            ModelMappingORM.model_type != "alias",
+                        ),
+                        ModelMappingORM.is_active == is_active,
+                    ),
+                    and_(
+                        ModelMappingORM.model_type == "alias",
+                        alias_target_has_status,
+                    ),
+                )
+            )
             
         if requested_model:
             conditions.append(ModelMappingORM.requested_model.ilike(f"%{requested_model}%"))

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -130,15 +130,15 @@ class ModelService:
                 code="model_not_found",
             )
 
-        if not mapping.is_active:
-            raise ServiceError(
-                message=f"Model '{requested_model}' is disabled",
-                code="model_disabled",
-            )
-
         routing_model, mapping = await resolve_alias_target(
             self.model_repo, requested_model, mapping
         )
+
+        if not mapping.is_active:
+            raise ServiceError(
+                message=f"Model '{routing_model}' is disabled",
+                code="model_disabled",
+            )
 
         provider_mappings = await self.model_repo.get_provider_mappings(
             requested_model=routing_model,
@@ -381,6 +381,8 @@ class ModelService:
                 "cached_input_price": None,
                 "cached_output_price": None,
                 "cache_creation_input_price": None,
+                "is_active": True,
+                "disable_thinking": False,
             }
         )
 
@@ -428,6 +430,8 @@ class ModelService:
                 "cached_input_price": None,
                 "cached_output_price": None,
                 "cache_creation_input_price": None,
+                "is_active": True,
+                "disable_thinking": False,
             }
         )
 
@@ -808,6 +812,7 @@ class ModelService:
                     alias_target_model=m.alias_target_model,
                     capabilities=m.capabilities,
                     is_active=m.is_active,
+                    disable_thinking=m.disable_thinking,
                     input_price=m.input_price,
                     output_price=m.output_price,
                     billing_mode=m.billing_mode,
@@ -915,10 +920,18 @@ class ModelService:
         Returns:
             ModelMappingResponse: Response model
         """
+        effective_mapping = mapping
+        effective_requested_model = mapping.requested_model
+        if mapping.model_type == "alias" and mapping.alias_target_model:
+            target_mapping = await self.model_repo.get_mapping(mapping.alias_target_model)
+            if target_mapping is not None:
+                effective_mapping = target_mapping
+                effective_requested_model = target_mapping.requested_model
+
         providers = None
         if include_providers:
             providers = await self.model_repo.get_provider_mappings(
-                requested_model=mapping.requested_model
+                requested_model=effective_requested_model
             )
             if self._health_tracker is not None and providers:
                 health_by_mapping = await self._health_tracker.get_mapping_snapshots(
@@ -940,29 +953,30 @@ class ModelService:
             )
         else:
             provider_count = await self.model_repo.get_provider_count(
-                mapping.requested_model
+                effective_requested_model
             )
             active_provider_count = await self.model_repo.get_active_provider_count(
-                mapping.requested_model
+                effective_requested_model
             )
         
         return ModelMappingResponse(
             requested_model=mapping.requested_model,
-            strategy=mapping.strategy,
+            strategy=effective_mapping.strategy,
             model_type=mapping.model_type,
             alias_target_model=mapping.alias_target_model,
-            capabilities=mapping.capabilities,
-            is_active=mapping.is_active,
-            input_price=mapping.input_price,
-            output_price=mapping.output_price,
-            billing_mode=mapping.billing_mode,
-            per_request_price=mapping.per_request_price,
-            per_image_price=mapping.per_image_price,
-            tiered_pricing=mapping.tiered_pricing,
-            cache_billing_enabled=mapping.cache_billing_enabled,
-            cached_input_price=mapping.cached_input_price,
-            cached_output_price=mapping.cached_output_price,
-            cache_creation_input_price=mapping.cache_creation_input_price,
+            capabilities=effective_mapping.capabilities,
+            is_active=effective_mapping.is_active,
+            disable_thinking=effective_mapping.disable_thinking,
+            input_price=effective_mapping.input_price,
+            output_price=effective_mapping.output_price,
+            billing_mode=effective_mapping.billing_mode,
+            per_request_price=effective_mapping.per_request_price,
+            per_image_price=effective_mapping.per_image_price,
+            tiered_pricing=effective_mapping.tiered_pricing,
+            cache_billing_enabled=effective_mapping.cache_billing_enabled,
+            cached_input_price=effective_mapping.cached_input_price,
+            cached_output_price=effective_mapping.cached_output_price,
+            cache_creation_input_price=effective_mapping.cache_creation_input_price,
             created_at=mapping.created_at,
             updated_at=mapping.updated_at,
             provider_count=provider_count,

--- a/backend/app/services/proxy_service.py
+++ b/backend/app/services/proxy_service.py
@@ -24,6 +24,7 @@ from app.common.protocol_conversion import (
     normalize_protocol,
 )
 from app.common.provider_protocols import resolve_implementation_protocol
+from app.common.reasoning import force_disable_reasoning_for_supplier
 from app.common.proxy import build_proxy_config
 from app.common.sanitizer import sanitize_headers
 from app.common.stream_usage import StreamUsageAccumulator
@@ -548,15 +549,14 @@ class ProxyService:
                     code="model_not_found",
                 )
 
-            if not model_mapping.is_active:
-                raise ServiceError(
-                    message=f"Model '{requested_model}' is disabled",
-                    code="model_disabled",
-                )
-
             routing_model, model_mapping = await resolve_alias_target(
                 model_repo, requested_model, model_mapping
             )
+            if not model_mapping.is_active:
+                raise ServiceError(
+                    message=f"Model '{routing_model}' is disabled",
+                    code="model_disabled",
+                )
             if routing_model != requested_model:
                 body["model"] = routing_model
                 logger.info(
@@ -928,6 +928,12 @@ class ProxyService:
                     )
                     if hooked_image_supplier_body is not None:
                         supplier_body = hooked_image_supplier_body
+                if model_mapping.disable_thinking:
+                    supplier_body = force_disable_reasoning_for_supplier(
+                        supplier_body,
+                        supplier_protocol=candidate.protocol,
+                        target_model=candidate.target_model,
+                    )
                 # Track conversion data for logging
                 conversion_data["supplier_protocol"] = supplier_protocol
                 conversion_data["converted_request_body"] = supplier_body
@@ -957,7 +963,12 @@ class ProxyService:
                     response_timeout_seconds=candidate.response_timeout_seconds,
                 )
             except Exception as e:
-                error_msg = str(e)
+                error_msg = (
+                    f"{e.code}: {e.message}"
+                    if isinstance(e, ServiceError)
+                    and e.code == "thinking_disable_unsupported"
+                    else str(e)
+                )
                 logger.error(
                     "Error during request forwarding: provider_id=%s, provider_name=%s, "
                     "request_protocol=%s, supplier_protocol=%s, error=%s",
@@ -1035,7 +1046,12 @@ class ProxyService:
                         response_body = hooked_image_response_body
                 result.response.body = response_body
             except Exception as e:
-                error_msg = str(e)
+                error_msg = (
+                    f"{e.code}: {e.message}"
+                    if isinstance(e, ServiceError)
+                    and e.code == "thinking_disable_unsupported"
+                    else str(e)
+                )
                 logger.error(
                     "Error during response conversion: provider_id=%s, provider_name=%s, "
                     "request_protocol=%s, supplier_protocol=%s, error=%s",
@@ -1428,6 +1444,12 @@ class ProxyService:
                     )
                     if hooked_image_supplier_body is not None:
                         supplier_body = hooked_image_supplier_body
+                if model_mapping.disable_thinking:
+                    supplier_body = force_disable_reasoning_for_supplier(
+                        supplier_body,
+                        supplier_protocol=candidate.protocol,
+                        target_model=candidate.target_model,
+                    )
                 # Track conversion data for logging
                 stream_conversion_data["supplier_protocol"] = supplier_protocol
                 stream_conversion_data["converted_request_body"] = supplier_body

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -21,6 +21,7 @@ psql -U username -d database_name -f migrations/add_is_stream_column.sql
 - `add_is_stream_column.sql` - Adds the `is_stream` boolean field to the `request_logs` table to indicate whether a request is a stream request.
 - `add_extra_headers_column.sql` - Adds the `extra_headers` JSON field to the `service_providers` table for custom headers.
 - `add_provider_options_column.sql` - Adds the `provider_options` JSON field to the `service_providers` table for provider options.
+- `add_disable_thinking_column.sql` - Adds the model-level flag that forces provider-specific thinking controls off.
 - `add_protocol_conversion_columns.sql` - Adds protocol conversion tracking columns to `request_logs` for debugging and analysis:
   - `request_protocol` - Client request protocol (openai/anthropic)
   - `supplier_protocol` - Upstream supplier protocol (openai/anthropic)

--- a/backend/migrations/add_disable_thinking_column.sql
+++ b/backend/migrations/add_disable_thinking_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE model_mappings
+ADD COLUMN disable_thinking BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/tests/integration/test_admin_models.py
+++ b/backend/tests/integration/test_admin_models.py
@@ -44,7 +44,11 @@ async def test_admin_creates_and_updates_alias_for_real_model(db_session, monkey
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         real_resp = await ac.post(
             "/api/admin/models",
-            json={"requested_model": "gpt-4o", "model_type": "chat"},
+            json={
+                "requested_model": "gpt-4o",
+                "model_type": "chat",
+                "disable_thinking": True,
+            },
         )
         assert real_resp.status_code == 201, real_resp.text
 
@@ -54,11 +58,14 @@ async def test_admin_creates_and_updates_alias_for_real_model(db_session, monkey
                 "requested_model": "gpt-latest",
                 "model_type": "alias",
                 "alias_target_model": "gpt-4o",
-                "is_active": True,
+                "is_active": False,
+                "disable_thinking": False,
             },
         )
         assert alias_resp.status_code == 201, alias_resp.text
         assert alias_resp.json()["alias_target_model"] == "gpt-4o"
+        assert alias_resp.json()["is_active"] is True
+        assert alias_resp.json()["disable_thinking"] is True
 
         fallback_resp = await ac.post(
             "/api/admin/models",
@@ -83,7 +90,26 @@ async def test_admin_creates_and_updates_alias_for_real_model(db_session, monkey
         assert update_resp.status_code == 200, update_resp.text
         assert update_resp.json()["model_type"] == "alias"
         assert update_resp.json()["alias_target_model"] == "gpt-4o"
-        assert update_resp.json()["is_active"] is False
+        assert update_resp.json()["is_active"] is True
+        assert update_resp.json()["disable_thinking"] is True
+
+        disable_target_resp = await ac.put(
+            "/api/admin/models/gpt-4o",
+            json={"is_active": False},
+        )
+        assert disable_target_resp.status_code == 200, disable_target_resp.text
+
+        alias_detail_resp = await ac.get("/api/admin/models/gpt-latest")
+        assert alias_detail_resp.status_code == 200, alias_detail_resp.text
+        assert alias_detail_resp.json()["is_active"] is False
+        assert alias_detail_resp.json()["disable_thinking"] is True
+
+        inactive_list_resp = await ac.get("/api/admin/models?is_active=false")
+        assert inactive_list_resp.status_code == 200, inactive_list_resp.text
+        inactive_names = {
+            item["requested_model"] for item in inactive_list_resp.json()["items"]
+        }
+        assert {"gpt-4o", "gpt-latest"} <= inactive_names
 
     app.dependency_overrides = {}
 

--- a/backend/tests/unit/test_common/test_reasoning_force_disable.py
+++ b/backend/tests/unit/test_common/test_reasoning_force_disable.py
@@ -102,9 +102,26 @@ def test_force_disable_gemini_3_flash_uses_minimal_level():
     }
 
 
+@pytest.mark.parametrize("model", ["gemini-1.5-flash", "gemini-2.0-flash"])
+def test_force_disable_non_thinking_legacy_gemini_removes_stale_control(model):
+    result = force_disable_reasoning_for_supplier(
+        {
+            "generationConfig": {
+                "temperature": 0.5,
+                "thinkingConfig": {"thinkingBudget": 1024},
+            }
+        },
+        supplier_protocol="gemini",
+        target_model=model,
+    )
+
+    assert result["generationConfig"] == {"temperature": 0.5}
+
+
 @pytest.mark.parametrize(
     "model",
     [
+        "gemini-2.0-flash-thinking-exp-01-21",
         "gemini-2.5-pro",
         "gemini-3-pro-preview",
         "gemini-3.7-flash",

--- a/backend/tests/unit/test_common/test_reasoning_force_disable.py
+++ b/backend/tests/unit/test_common/test_reasoning_force_disable.py
@@ -1,0 +1,130 @@
+import pytest
+
+from app.common.errors import ServiceError
+from app.common.reasoning import force_disable_reasoning_for_supplier
+
+
+@pytest.mark.parametrize("protocol", ["openai", "openai_responses"])
+def test_force_disable_openai_overrides_conflicting_controls(protocol):
+    result = force_disable_reasoning_for_supplier(
+        {
+            "reasoning": {"effort": "high"},
+            "thinking": {"type": "enabled"},
+            "enable_thinking": True,
+            "output_config": {"effort": "max"},
+        },
+        supplier_protocol=protocol,
+        target_model="gpt-test",
+    )
+
+    assert result["reasoning"] == {"effort": "none"}
+    assert "thinking" not in result
+    assert "enable_thinking" not in result
+    assert "output_config" not in result
+
+
+@pytest.mark.parametrize("protocol", ["deepseek", "zhipu", "moonshot", "ark"])
+def test_force_disable_deepseek_compatible_protocols(protocol):
+    result = force_disable_reasoning_for_supplier(
+        {"reasoning": {"effort": "high"}, "thinking": {"type": "enabled"}},
+        supplier_protocol=protocol,
+        target_model="reasoning-model",
+    )
+
+    assert result["thinking"] == {"type": "disabled"}
+    assert "reasoning" not in result
+
+
+def test_force_disable_anthropic_removes_effort():
+    result = force_disable_reasoning_for_supplier(
+        {
+            "thinking": {"type": "enabled", "budget_tokens": 4096},
+            "output_config": {"effort": "high"},
+        },
+        supplier_protocol="anthropic",
+        target_model="claude-test",
+    )
+
+    assert result["thinking"] == {"type": "disabled"}
+    assert "output_config" not in result
+
+
+def test_force_disable_preserves_unrelated_output_config_fields():
+    result = force_disable_reasoning_for_supplier(
+        {"output_config": {"effort": "high", "format": "json"}},
+        supplier_protocol="openai",
+        target_model="gpt-test",
+    )
+
+    assert result["output_config"] == {"format": "json"}
+
+
+def test_force_disable_dashscope():
+    result = force_disable_reasoning_for_supplier(
+        {"enable_thinking": True, "reasoning": {"effort": "high"}},
+        supplier_protocol="aliyun",
+        target_model="qwen-test",
+    )
+
+    assert result["enable_thinking"] is False
+    assert "reasoning" not in result
+
+
+def test_force_disable_gemini_25_flash_preserves_generation_config():
+    result = force_disable_reasoning_for_supplier(
+        {
+            "generationConfig": {
+                "temperature": 0.5,
+                "thinkingConfig": {"thinkingBudget": 1024},
+            }
+        },
+        supplier_protocol="gemini",
+        target_model="gemini-2.5-flash-preview",
+    )
+
+    assert result["generationConfig"]["temperature"] == 0.5
+    assert result["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": False,
+        "thinkingBudget": 0,
+    }
+
+
+def test_force_disable_gemini_3_flash_uses_minimal_level():
+    result = force_disable_reasoning_for_supplier(
+        {"generationConfig": {"thinkingConfig": {"thinkingLevel": "high"}}},
+        supplier_protocol="gemini",
+        target_model="models/gemini-3-flash-preview",
+    )
+
+    assert result["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": False,
+        "thinkingLevel": "minimal",
+    }
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gemini-2.5-pro",
+        "gemini-3-pro-preview",
+        "gemini-3.7-flash",
+        "gemini-future",
+    ],
+)
+def test_force_disable_rejects_gemini_models_without_supported_off_control(model):
+    with pytest.raises(ServiceError) as exc_info:
+        force_disable_reasoning_for_supplier(
+            {}, supplier_protocol="gemini", target_model=model
+        )
+
+    assert exc_info.value.code == "thinking_disable_unsupported"
+
+
+def test_force_disable_does_not_mutate_input():
+    source = {"reasoning": {"effort": "high"}}
+
+    force_disable_reasoning_for_supplier(
+        source, supplier_protocol="openai", target_model="gpt-test"
+    )
+
+    assert source == {"reasoning": {"effort": "high"}}

--- a/backend/tests/unit/test_db_in_progress_migration.py
+++ b/backend/tests/unit/test_db_in_progress_migration.py
@@ -75,6 +75,42 @@ def test_startup_adds_alias_target_model_to_existing_model_table():
     assert "alias_target_model" in columns
 
 
+def test_startup_adds_disable_thinking_with_false_default_to_existing_models():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE model_mappings ("
+                "requested_model VARCHAR(100) PRIMARY KEY, "
+                "model_type VARCHAR(50)"
+                ")"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO model_mappings(requested_model, model_type) "
+                "VALUES ('legacy-model', 'chat')"
+            )
+        )
+
+        _run_migrations(connection)
+
+        columns = {
+            column["name"]: column
+            for column in inspect(connection).get_columns("model_mappings")
+        }
+        value = connection.execute(
+            text(
+                "SELECT disable_thinking FROM model_mappings "
+                "WHERE requested_model = 'legacy-model'"
+            )
+        ).scalar_one()
+
+    engine.dispose()
+    assert columns["disable_thinking"]["nullable"] is False
+    assert value in (False, 0)
+
+
 def test_startup_enforces_alias_target_integrity_on_existing_sqlite_table():
     engine = create_engine("sqlite:///:memory:")
     with engine.begin() as connection:

--- a/backend/tests/unit/test_repositories/test_model_repo_create.py
+++ b/backend/tests/unit/test_repositories/test_model_repo_create.py
@@ -37,6 +37,19 @@ class TestCreateMappingPersistsPricingFields:
         assert result.input_price == 5.0
         assert result.output_price == 15.0
 
+    async def test_create_mapping_persists_disable_thinking(self, model_repo):
+        data = ModelMappingCreate(
+            requested_model="test-disable-thinking",
+            disable_thinking=True,
+        )
+
+        result = await model_repo.create_mapping(data)
+        fetched = await model_repo.get_mapping("test-disable-thinking")
+
+        assert result.disable_thinking is True
+        assert fetched is not None
+        assert fetched.disable_thinking is True
+
     async def test_create_mapping_persists_token_tiered(self, model_repo):
         data = ModelMappingCreate(
             requested_model="test-tiered",

--- a/backend/tests/unit/test_services/test_import_export.py
+++ b/backend/tests/unit/test_services/test_import_export.py
@@ -1,7 +1,8 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
+from app.common.time import utc_now
 from app.domain.provider import ProviderCreate, Provider
-from app.domain.model import ModelExport, ModelProviderExport
+from app.domain.model import ModelExport, ModelMapping, ModelProviderExport
 from app.services.provider_service import ProviderService
 from app.services.model_service import ModelService
 
@@ -53,6 +54,7 @@ async def test_model_import_success(model_service, model_repo, provider_repo):
     model_export = ModelExport(
         requested_model="model1",
         strategy="round_robin",
+        disable_thinking=True,
         providers=[provider_export]
     )
     data = [model_export]
@@ -71,6 +73,7 @@ async def test_model_import_success(model_service, model_repo, provider_repo):
     
     # Check calls
     assert model_repo.create_mapping.call_count == 1
+    assert model_repo.create_mapping.call_args.args[0].disable_thinking is True
     assert model_repo.add_provider_mapping.call_count == 1
     # Verify provider mapping creation uses correct provider_id
     call_args = model_repo.add_provider_mapping.call_args[0][0]
@@ -116,6 +119,8 @@ async def test_model_import_validates_and_normalizes_aliases(
         alias_target_model="real-model",
         strategy="cost_first",
         matching_rules={"headers": {"x-tenant": "legacy"}},
+        is_active=False,
+        disable_thinking=True,
         providers=[
             ModelProviderExport(
                 provider_name="p1",
@@ -149,4 +154,30 @@ async def test_model_import_validates_and_normalizes_aliases(
     assert imported_alias.strategy == "round_robin"
     assert imported_alias.matching_rules is None
     assert imported_alias.alias_target_model == "real-model"
+    assert imported_alias.is_active is True
+    assert imported_alias.disable_thinking is False
     model_repo.add_provider_mapping.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_export_includes_disable_thinking(
+    model_service, model_repo
+):
+    now = utc_now()
+    model_repo.get_all_mappings.return_value = (
+        [
+            ModelMapping(
+                requested_model="reasoning-model",
+                disable_thinking=True,
+                created_at=now,
+                updated_at=now,
+            )
+        ],
+        1,
+    )
+    model_repo.get_provider_mappings.return_value = []
+
+    exported = await model_service.export_data()
+
+    assert len(exported) == 1
+    assert exported[0].disable_thinking is True

--- a/backend/tests/unit/test_services/test_protocol_hooks.py
+++ b/backend/tests/unit/test_services/test_protocol_hooks.py
@@ -17,7 +17,11 @@ class RecordingHooks(ProtocolConversionHooks):
         return {**body, "before": True}
 
     async def after_request_conversion(self, supplier_body, request_protocol, supplier_protocol):
-        return {**supplier_body, "after": True}
+        return {
+            **supplier_body,
+            "after": True,
+            "thinking": {"type": "enabled", "budget_tokens": 4096},
+        }
 
     async def before_response_conversion(self, supplier_body, request_protocol, supplier_protocol):
         return {"wrapped": supplier_body}
@@ -27,6 +31,9 @@ class RecordingHooks(ProtocolConversionHooks):
 
 
 class StreamHooks(ProtocolConversionHooks):
+    async def after_request_conversion(self, supplier_body, request_protocol, supplier_protocol):
+        return {**supplier_body, "thinking": {"type": "enabled"}}
+
     async def before_stream_chunk_conversion(self, chunk, request_protocol, supplier_protocol):
         return chunk.replace(b"message_start", b"message_start_hooked")
 
@@ -65,6 +72,7 @@ async def test_protocol_hooks_apply_to_non_stream_flow():
         matching_rules=None,
         capabilities=None,
         is_active=True,
+        disable_thinking=True,
         created_at=now,
         updated_at=now,
     )
@@ -91,6 +99,7 @@ async def test_protocol_hooks_apply_to_non_stream_flow():
 
     async def forward(*, body: dict, **kwargs):
         assert body["after"] is True
+        assert body["thinking"] == {"type": "disabled"}
         return ProviderResponse(
             status_code=200,
             headers={"content-type": "application/json"},
@@ -231,6 +240,7 @@ async def test_protocol_hooks_apply_to_stream_chunks():
         matching_rules=None,
         capabilities=None,
         is_active=True,
+        disable_thinking=True,
         created_at=now,
         updated_at=now,
     )
@@ -256,6 +266,8 @@ async def test_protocol_hooks_apply_to_stream_chunks():
     )  # type: ignore[method-assign]
 
     def forward_stream(**kwargs):
+        assert kwargs["body"]["thinking"] == {"type": "disabled"}
+
         async def gen():
             response = ProviderResponse(status_code=200, headers={})
             yield b'data: {"type":"message_start"}\n\n', response

--- a/backend/tests/unit/test_services/test_proxy_service_protocol_matching.py
+++ b/backend/tests/unit/test_services/test_proxy_service_protocol_matching.py
@@ -147,7 +147,7 @@ async def test_resolve_candidates_rewrites_alias_to_real_model():
         requested_model="gpt-latest",
         model_type="alias",
         alias_target_model="gpt-4o",
-        is_active=True,
+        is_active=False,
         created_at=now,
         updated_at=now,
     )
@@ -155,6 +155,7 @@ async def test_resolve_candidates_rewrites_alias_to_real_model():
         requested_model="gpt-4o",
         model_type="chat",
         is_active=True,
+        disable_thinking=True,
         created_at=now,
         updated_at=now,
     )
@@ -198,6 +199,7 @@ async def test_resolve_candidates_rewrites_alias_to_real_model():
         )
 
     assert mapping.requested_model == "gpt-4o"
+    assert mapping.disable_thinking is True
     assert body["model"] == "gpt-4o"
     assert [candidate.target_model for candidate in candidates] == ["gpt-4o-2024-08-06"]
     log_info.assert_called_once_with(

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -453,7 +453,10 @@
       "costFirstDescription": "Prioritize providers with the lowest estimated cost",
       "costFirstTag": "Cost Optimization",
       "strategyHint": "Choose how the gateway selects providers for this model",
-      "enabledStatusLabel": "Enabled Status"
+      "advancedLabel": "Advanced",
+      "enabledStatusLabel": "Enabled Status",
+      "disableThinkingLabel": "Disable Thinking",
+      "disableThinkingHelp": "When enabled, the gateway overrides request parameters and disables thinking using the selected provider protocol."
     },
     "detail": {
       "missingModelParam": "Missing model parameter",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -453,7 +453,10 @@
       "costFirstDescription": "优先选择预计成本最低的供应商",
       "costFirstTag": "成本优化",
       "strategyHint": "选择网关如何为该模型选择供应商",
-      "enabledStatusLabel": "启用状态"
+      "advancedLabel": "高级",
+      "enabledStatusLabel": "启用状态",
+      "disableThinkingLabel": "关闭思考模式",
+      "disableThinkingHelp": "开启后，网关会覆盖请求参数，并按实际供应商协议强制关闭思考模式。"
     },
     "detail": {
       "missingModelParam": "缺少模型参数",

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -5,9 +5,10 @@
 
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm, Controller, useFieldArray, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
+import { ChevronDown } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -35,7 +36,7 @@ import {
   ModelType,
   SelectionStrategy
 } from '@/types';
-import { isValidModelName } from '@/lib/utils';
+import { cn, isValidModelName } from '@/lib/utils';
 import { ModelProviderBillingFields } from '@/components/models/ModelProviderBillingFields';
 import type { BillingMode } from '@/components/models/ModelProviderBillingFields';
 
@@ -64,6 +65,7 @@ interface FormData {
   model_type: ModelType;
   alias_target_model: string;
   is_active: boolean;
+  disable_thinking: boolean;
   billing_mode: BillingMode;
   input_price: string;
   output_price: string;
@@ -111,6 +113,7 @@ export function ModelForm({
       model_type: 'chat',
       alias_target_model: '',
       is_active: true,
+      disable_thinking: false,
       billing_mode: 'token_flat' as BillingMode,
       input_price: '',
       output_price: '',
@@ -130,12 +133,21 @@ export function ModelForm({
   });
 
   const isActive = useWatch({ control, name: 'is_active' });
+  const disableThinking = useWatch({ control, name: 'disable_thinking' });
   const modelType = useWatch({ control, name: 'model_type' });
   const isAlias = modelType === 'alias';
   const strategy = useWatch({ control, name: 'strategy' });
   const billingMode = useWatch({ control, name: 'billing_mode' });
   const cacheBillingEnabled = useWatch({ control, name: 'cache_billing_enabled' });
   const supportsBilling = modelType === 'chat' || modelType === 'embedding' || modelType === 'images';
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setAdvancedOpen(false);
+    }
+    onOpenChange(nextOpen);
+  };
 
   useEffect(() => {
     if (!supportsBilling && strategy === 'cost_first') {
@@ -153,6 +165,7 @@ export function ModelForm({
         model_type: model.model_type ?? 'chat',
         alias_target_model: model.alias_target_model ?? '',
         is_active: model.is_active,
+        disable_thinking: model.disable_thinking ?? false,
         billing_mode: mode,
         input_price:
           model.input_price === null || model.input_price === undefined
@@ -196,6 +209,7 @@ export function ModelForm({
         model_type: 'chat',
         alias_target_model: '',
         is_active: true,
+        disable_thinking: false,
         billing_mode: 'token_flat' as BillingMode,
         input_price: '',
         output_price: '',
@@ -216,11 +230,11 @@ export function ModelForm({
       const submitData: ModelMappingCreate | ModelMappingUpdate = {
         model_type: 'alias',
         alias_target_model: data.alias_target_model,
-        is_active: data.is_active,
       };
       if (!isEdit) {
         (submitData as ModelMappingCreate).requested_model = data.requested_model;
       }
+      setAdvancedOpen(false);
       onSubmit(submitData);
       return;
     }
@@ -235,6 +249,7 @@ export function ModelForm({
       model_type: data.model_type,
       alias_target_model: null,
       is_active: data.is_active,
+      disable_thinking: data.disable_thinking,
     };
 
     // requested_model required on creation
@@ -319,11 +334,12 @@ export function ModelForm({
       submitData.cached_output_price = null;
     }
 
+    setAdvancedOpen(false);
     onSubmit(submitData);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[800px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
@@ -610,15 +626,56 @@ export function ModelForm({
             </p>
           </div>}
 
-          {/* Status */}
-          <div className="flex items-center justify-between">
-            <Label htmlFor="is_active">{t('form.enabledStatusLabel')}</Label>
-            <Switch
-              id="is_active"
-              checked={isActive}
-              onCheckedChange={(checked) => setValue('is_active', checked)}
-            />
-          </div>
+          {!isAlias && (
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen((value) => !value)}
+                className="flex w-full items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-medium hover:bg-muted"
+                aria-expanded={advancedOpen}
+              >
+                <span>{t('form.advancedLabel')}</span>
+                <ChevronDown
+                  className={cn(
+                    'h-4 w-4 transition-transform',
+                    advancedOpen && 'rotate-180'
+                  )}
+                  suppressHydrationWarning
+                />
+              </button>
+
+              {advancedOpen && (
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="is_active">{t('form.enabledStatusLabel')}</Label>
+                    <Switch
+                      id="is_active"
+                      checked={isActive}
+                      onCheckedChange={(checked) => setValue('is_active', checked)}
+                    />
+                  </div>
+
+                  <div className="space-y-2 rounded-md border border-border p-3">
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor="disable_thinking">
+                        {t('form.disableThinkingLabel')}
+                      </Label>
+                      <Switch
+                        id="disable_thinking"
+                        checked={disableThinking}
+                        onCheckedChange={(checked) =>
+                          setValue('disable_thinking', checked)
+                        }
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {t('form.disableThinkingHelp')}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
 
 
 
@@ -626,7 +683,7 @@ export function ModelForm({
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
               disabled={loading}
             >
               {tCommon('cancel')}

--- a/frontend/src/components/providers/ProviderForm.tsx
+++ b/frontend/src/components/providers/ProviderForm.tsx
@@ -130,6 +130,13 @@ export function ProviderForm({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const userHasEditedBaseUrl = useRef(false);
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setAdvancedOpen(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
   // Add header
   const addHeader = () => {
     setExtraHeaders([...extraHeaders, { key: '', value: '' }]);
@@ -343,11 +350,12 @@ export function ProviderForm({
       submitData.proxy_url = data.proxy_url;
     }
     
+    setAdvancedOpen(false);
     onSubmit(submitData);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[500px] max-h-[90vh] flex flex-col gap-4">
         <DialogHeader>
           <DialogTitle>{isEdit ? t('form.title.edit') : t('form.title.new')}</DialogTitle>
@@ -672,18 +680,18 @@ export function ProviderForm({
                     </div>
                   )}
                 </div>
+
+                {/* Status */}
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="is_active">{t('form.status.label')}</Label>
+                  <Switch
+                    id="is_active"
+                    checked={isActive}
+                    onCheckedChange={(checked) => setValue('is_active', checked)}
+                  />
+                </div>
               </div>
             )}
-          </div>
-
-          {/* Status */}
-          <div className="flex items-center justify-between">
-            <Label htmlFor="is_active">{t('form.status.label')}</Label>
-            <Switch
-              id="is_active"
-              checked={isActive}
-              onCheckedChange={(checked) => setValue('is_active', checked)}
-            />
           </div>
         </form>
 
@@ -691,7 +699,7 @@ export function ProviderForm({
           <Button
             type="button"
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={loading}
           >
             {t('form.actions.cancel')}

--- a/frontend/src/types/model.ts
+++ b/frontend/src/types/model.ts
@@ -25,6 +25,7 @@ export interface ModelMapping {
   alias_target_model?: string | null; // Real model referenced by an alias
   capabilities?: Record<string, unknown>; // Capabilities description
   is_active: boolean;
+  disable_thinking: boolean;
   // Pricing (USD per 1,000,000 tokens)
   input_price?: number | null;
   output_price?: number | null;
@@ -121,6 +122,7 @@ export interface ModelMappingCreate {
   alias_target_model?: string | null;
   capabilities?: Record<string, unknown>;
   is_active?: boolean;
+  disable_thinking?: boolean;
   input_price?: number | null;
   output_price?: number | null;
   billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;
@@ -147,6 +149,7 @@ export interface ModelMappingUpdate {
   alias_target_model?: string | null;
   capabilities?: Record<string, unknown>;
   is_active?: boolean;
+  disable_thinking?: boolean;
   input_price?: number | null;
   output_price?: number | null;
   billing_mode?: 'token_flat' | 'token_tiered' | 'per_request' | 'per_image' | null;


### PR DESCRIPTION
## Summary

- add model-level `disable_thinking` configuration with database migration, CRUD, import/export, and admin UI support
- enforce provider-specific no-thinking controls after protocol conversion and hooks for streaming and non-streaming requests
- make aliases inherit all runtime configuration from their concrete model and move model/provider status controls into Advanced
- support Gemini capability-specific controls and fail closed for models without a documented off/minimal control

## Review fixes

- reject legacy `gemini-2.0-flash-thinking-*` models instead of silently treating them as non-thinking
- verify startup migration adds a non-null `disable_thinking=false` value to existing model rows

## Tests

- `backend/.venv/bin/pytest -q` — 769 passed
- reasoning module coverage — 92%
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

## UI verification

- Production build and TypeScript checks pass; no screenshot attached because the change is confined to existing admin form controls and does not introduce a new page.

Closes GUL-45
