### PR TITLE
GUL-45: 优化高级设置区域样式

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -348,7 +348,8 @@
         "label": "Advanced"
       },
       "status": {
-        "label": "Enabled Status"
+        "label": "Enabled Status",
+        "help": "Controls whether this provider can receive requests."
       },
       "actions": {
         "cancel": "Cancel",
@@ -455,6 +456,7 @@
       "strategyHint": "Choose how the gateway selects providers for this model",
       "advancedLabel": "Advanced",
       "enabledStatusLabel": "Enabled Status",
+      "enabledStatusHelp": "Controls whether this model can receive requests.",
       "disableThinkingLabel": "Disable Thinking",
       "disableThinkingHelp": "When enabled, the gateway overrides request parameters and disables thinking using the selected provider protocol."
     },

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -348,7 +348,8 @@
         "label": "高级"
       },
       "status": {
-        "label": "启用状态"
+        "label": "启用状态",
+        "help": "控制该供应商是否可以接收请求。"
       },
       "actions": {
         "cancel": "取消",
@@ -455,6 +456,7 @@
       "strategyHint": "选择网关如何为该模型选择供应商",
       "advancedLabel": "高级",
       "enabledStatusLabel": "启用状态",
+      "enabledStatusHelp": "控制该模型是否可以接收请求。",
       "disableThinkingLabel": "关闭思考模式",
       "disableThinkingHelp": "开启后，网关会覆盖请求参数，并按实际供应商协议强制关闭思考模式。"
     },

--- a/frontend/src/components/models/ModelForm.tsx
+++ b/frontend/src/components/models/ModelForm.tsx
@@ -8,7 +8,6 @@
 import React, { useEffect, useState } from 'react';
 import { useForm, Controller, useFieldArray, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
-import { ChevronDown } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -21,6 +20,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Card } from '@/components/ui/card';
+import { AdvancedSection } from '@/components/ui/advanced-section';
 import {
   Select,
   SelectContent,
@@ -627,54 +627,46 @@ export function ModelForm({
           </div>}
 
           {!isAlias && (
-            <div className="space-y-3">
-              <button
-                type="button"
-                onClick={() => setAdvancedOpen((value) => !value)}
-                className="flex w-full items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-medium hover:bg-muted"
-                aria-expanded={advancedOpen}
-              >
-                <span>{t('form.advancedLabel')}</span>
-                <ChevronDown
-                  className={cn(
-                    'h-4 w-4 transition-transform',
-                    advancedOpen && 'rotate-180'
-                  )}
-                  suppressHydrationWarning
-                />
-              </button>
-
-              {advancedOpen && (
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <Label htmlFor="is_active">{t('form.enabledStatusLabel')}</Label>
-                    <Switch
-                      id="is_active"
-                      checked={isActive}
-                      onCheckedChange={(checked) => setValue('is_active', checked)}
-                    />
-                  </div>
-
-                  <div className="space-y-2 rounded-md border border-border p-3">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor="disable_thinking">
-                        {t('form.disableThinkingLabel')}
-                      </Label>
-                      <Switch
-                        id="disable_thinking"
-                        checked={disableThinking}
-                        onCheckedChange={(checked) =>
-                          setValue('disable_thinking', checked)
-                        }
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {t('form.disableThinkingHelp')}
-                    </p>
-                  </div>
+            <AdvancedSection
+              label={t('form.advancedLabel')}
+              open={advancedOpen}
+              onOpenChange={setAdvancedOpen}
+              contentClassName="divide-y divide-border p-0"
+            >
+              <div className="flex items-start justify-between gap-6 px-4 py-4">
+                <div className="space-y-1">
+                  <Label htmlFor="is_active">{t('form.enabledStatusLabel')}</Label>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    {t('form.enabledStatusHelp')}
+                  </p>
                 </div>
-              )}
-            </div>
+                <Switch
+                  id="is_active"
+                  className="mt-0.5"
+                  checked={isActive}
+                  onCheckedChange={(checked) => setValue('is_active', checked)}
+                />
+              </div>
+
+              <div className="flex items-start justify-between gap-6 px-4 py-4">
+                <div className="space-y-1">
+                  <Label htmlFor="disable_thinking">
+                    {t('form.disableThinkingLabel')}
+                  </Label>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    {t('form.disableThinkingHelp')}
+                  </p>
+                </div>
+                <Switch
+                  id="disable_thinking"
+                  className="mt-0.5"
+                  checked={disableThinking}
+                  onCheckedChange={(checked) =>
+                    setValue('disable_thinking', checked)
+                  }
+                />
+              </div>
+            </AdvancedSection>
           )}
 
 

--- a/frontend/src/components/providers/ProviderForm.tsx
+++ b/frontend/src/components/providers/ProviderForm.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
-import { ChevronDown, CircleHelp, Plus, Trash2 } from 'lucide-react';
+import { CircleHelp, Plus, Trash2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { AdvancedSection } from '@/components/ui/advanced-section';
 import {
   Tooltip,
   TooltipContent,
@@ -35,7 +36,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { Provider, ProviderCreate, ProviderUpdate, ProtocolType } from '@/types';
-import { isValidUrl, isNotEmpty, cn } from '@/lib/utils';
+import { isValidUrl, isNotEmpty } from '@/lib/utils';
 import {
   getProviderProtocolConfig,
   useProviderProtocolConfigs,
@@ -480,27 +481,14 @@ export function ProviderForm({
           </div>
 
           {/* Advanced (collapsed by default) */}
-          <div className="space-y-3">
-            <button
-              type="button"
-              onClick={() => setAdvancedOpen((v) => !v)}
-              className="flex w-full items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2 text-sm font-medium hover:bg-muted"
-              aria-expanded={advancedOpen}
-            >
-              <span>{t('form.advanced.label')}</span>
-              <ChevronDown
-                className={cn(
-                  'h-4 w-4 transition-transform',
-                  advancedOpen && 'rotate-180'
-                )}
-                suppressHydrationWarning
-              />
-            </button>
-
-            {advancedOpen && (
-              <div className="space-y-4">
-                {/* Extra Headers */}
-                <div className="space-y-2">
+          <AdvancedSection
+            label={t('form.advanced.label')}
+            open={advancedOpen}
+            onOpenChange={setAdvancedOpen}
+            contentClassName="space-y-4"
+          >
+            {/* Extra Headers */}
+            <div className="space-y-2">
                   <div className="flex items-center justify-between">
                     <Label>{t('form.extraHeaders.label')}</Label>
                     <Button
@@ -681,18 +669,22 @@ export function ProviderForm({
                   )}
                 </div>
 
-                {/* Status */}
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="is_active">{t('form.status.label')}</Label>
-                  <Switch
-                    id="is_active"
-                    checked={isActive}
-                    onCheckedChange={(checked) => setValue('is_active', checked)}
-                  />
-                </div>
+            {/* Status */}
+            <div className="flex items-start justify-between gap-6 border-t border-border pt-4">
+              <div className="space-y-1">
+                <Label htmlFor="is_active">{t('form.status.label')}</Label>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  {t('form.status.help')}
+                </p>
               </div>
-            )}
-          </div>
+              <Switch
+                id="is_active"
+                className="mt-0.5"
+                checked={isActive}
+                onCheckedChange={(checked) => setValue('is_active', checked)}
+              />
+            </div>
+          </AdvancedSection>
         </form>
 
         <DialogFooter>

--- a/frontend/src/components/ui/advanced-section.tsx
+++ b/frontend/src/components/ui/advanced-section.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import * as React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface AdvancedSectionProps {
+  label: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+  contentClassName?: string;
+}
+
+/** A compact disclosure card shared by admin forms. */
+export function AdvancedSection({
+  label,
+  open,
+  onOpenChange,
+  children,
+  contentClassName,
+}: AdvancedSectionProps) {
+  const contentId = React.useId();
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        className={cn(
+          'flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium',
+          'transition-colors hover:bg-muted/50 focus-visible:outline-none',
+          'focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+          open && 'bg-muted/30'
+        )}
+        aria-expanded={open}
+        aria-controls={contentId}
+      >
+        <span>{label}</span>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 text-muted-foreground transition-transform',
+            open && 'rotate-180'
+          )}
+          suppressHydrationWarning
+        />
+      </button>
+
+      {open && (
+        <div
+          id={contentId}
+          className={cn('border-t border-border p-4', contentClassName)}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- replace the detached Advanced button/content layout with one cohesive disclosure card
- render model status and disable-thinking controls as aligned, consistently spaced setting rows
- reuse the same Advanced container in Provider forms and add concise status descriptions
- preserve collapsed-by-default behavior and all existing form values/submission semantics

## Verification

- checked the expanded/collapsed Model form in a real browser using the dark theme
- `npm run lint -- --quiet`
- `npm run build`
- translation JSON parsing
- `git diff --check`

Closes GUL-45
