### PR TITLE
GUL-77: 修复工具 schema 的 null required 转换

### DIFF
--- a/backend/tests/unit/test_common/test_protocol_conversion.py
+++ b/backend/tests/unit/test_common/test_protocol_conversion.py
@@ -527,6 +527,7 @@ async def test_convert_request_anthropic_to_openai_preserves_tools():
                     "input_schema": {
                         "type": "object",
                         "properties": {"city": {"type": "string"}},
+                        "required": None,
                     },
                 }
             ],
@@ -540,6 +541,7 @@ async def test_convert_request_anthropic_to_openai_preserves_tools():
     assert isinstance(out_body.get("tools"), list)
     assert out_body["tools"][0]["type"] == "function"
     assert out_body["tools"][0]["function"]["name"] == "get_weather"
+    assert "required" not in out_body["tools"][0]["function"]["parameters"]
     assert out_body.get("tool_choice") == {
         "type": "function",
         "function": {"name": "get_weather"},

--- a/llm_api_converter/api_protocol_converter/converters/openai_chat.py
+++ b/llm_api_converter/api_protocol_converter/converters/openai_chat.py
@@ -32,6 +32,7 @@ from ..ir import (
     ToolChoiceType,
 )
 from .exceptions import ConversionError, ValidationError
+from .schema_utils import omit_null_required
 
 
 class OpenAIChatDecoder:
@@ -767,7 +768,9 @@ class OpenAIChatEncoder:
             if tool.description:
                 encoded["function"]["description"] = tool.description
             if tool.parameters:
-                encoded["function"]["parameters"] = tool.parameters
+                encoded["function"]["parameters"] = omit_null_required(
+                    tool.parameters
+                )
             if tool.strict:
                 encoded["function"]["strict"] = True
             result.append(encoded)

--- a/llm_api_converter/api_protocol_converter/converters/openai_responses.py
+++ b/llm_api_converter/api_protocol_converter/converters/openai_responses.py
@@ -32,6 +32,7 @@ from ..ir import (
     ToolChoiceType,
 )
 from .exceptions import ConversionError, ValidationError
+from .schema_utils import omit_null_required
 
 
 class OpenAIResponsesDecoder:
@@ -771,7 +772,7 @@ class OpenAIResponsesEncoder:
             if tool.description:
                 encoded["description"] = tool.description
             if tool.parameters:
-                encoded["parameters"] = tool.parameters
+                encoded["parameters"] = omit_null_required(tool.parameters)
             if tool.strict:
                 encoded["strict"] = True
             result.append(encoded)

--- a/llm_api_converter/api_protocol_converter/converters/schema_utils.py
+++ b/llm_api_converter/api_protocol_converter/converters/schema_utils.py
@@ -1,0 +1,73 @@
+"""Helpers for normalizing JSON Schemas between provider protocols."""
+
+import copy
+from typing import Any, Dict
+
+_SCHEMA_MAP_KEYWORDS = (
+    "$defs",
+    "dependencies",
+    "definitions",
+    "dependentSchemas",
+    "patternProperties",
+    "properties",
+)
+_SCHEMA_SINGLE_KEYWORDS = (
+    "additionalItems",
+    "additionalProperties",
+    "contains",
+    "contentSchema",
+    "else",
+    "if",
+    "items",
+    "not",
+    "propertyNames",
+    "then",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+)
+_SCHEMA_LIST_KEYWORDS = ("allOf", "anyOf", "oneOf", "prefixItems")
+
+
+def omit_null_required(schema: Any) -> Any:
+    """Return a copy of a JSON Schema with null ``required`` values omitted.
+
+    Some schema generators serialize an absent optional ``required`` keyword as
+    ``null``. Anthropic accepts such tool schemas, but OpenAI-compatible APIs
+    validate the keyword as an array and reject the entire request. Traverse
+    only schema-bearing keywords so arbitrary values in ``default`` or
+    ``examples`` remain untouched.
+    """
+    cleaned = copy.deepcopy(schema)
+    if not isinstance(cleaned, dict):
+        return cleaned
+
+    _omit_null_required_in_place(cleaned)
+    return cleaned
+
+
+def _omit_null_required_in_place(schema: Dict[str, Any]) -> None:
+    if "required" in schema and schema["required"] is None:
+        schema.pop("required")
+
+    for keyword in _SCHEMA_MAP_KEYWORDS:
+        children = schema.get(keyword)
+        if isinstance(children, dict):
+            for child in children.values():
+                if isinstance(child, dict):
+                    _omit_null_required_in_place(child)
+
+    for keyword in _SCHEMA_SINGLE_KEYWORDS:
+        child = schema.get(keyword)
+        if isinstance(child, dict):
+            _omit_null_required_in_place(child)
+        elif keyword == "items" and isinstance(child, list):
+            for item in child:
+                if isinstance(item, dict):
+                    _omit_null_required_in_place(item)
+
+    for keyword in _SCHEMA_LIST_KEYWORDS:
+        children = schema.get(keyword)
+        if isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict):
+                    _omit_null_required_in_place(child)

--- a/llm_api_converter/tests/test_converters.py
+++ b/llm_api_converter/tests/test_converters.py
@@ -497,6 +497,39 @@ class TestAnthropicMessagesToOpenAIChat:
         # parameters instead of input_schema
         assert "parameters" in tool["function"]
 
+    def test_request_omits_null_required_from_tool_schema(self):
+        """OpenAI-compatible APIs require ``required`` to be an array."""
+        request = {
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "name": "get_artifacts_for_pull_request_description",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "options": {
+                                "type": "object",
+                                "properties": {"format": {"type": "string"}},
+                                "required": None,
+                            }
+                        },
+                        "required": None,
+                        "examples": [{"required": None}],
+                    },
+                }
+            ],
+        }
+
+        result = anthropic_messages_to_openai_chat_request(request)
+        schema = result["tools"][0]["function"]["parameters"]
+
+        assert "required" not in schema
+        assert "required" not in schema["properties"]["options"]
+        assert schema["examples"] == [{"required": None}]
+        assert request["tools"][0]["input_schema"]["required"] is None
+
     def test_multimodal_request(self):
         """Test multimodal (image) request conversion."""
         result = anthropic_messages_to_openai_chat_request(ANTHROPIC_MULTIMODAL_REQUEST)
@@ -543,6 +576,30 @@ class TestAnthropicMessagesToOpenAIResponses:
         assert result["max_output_tokens"] == 100
         # Simple single-message input may be simplified to a string
         assert "input" in result
+
+    def test_request_omits_null_required_from_tool_schema(self):
+        """Responses tool schemas receive the same null normalization."""
+        request = {
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "name": "get_artifacts_for_pull_request_description",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {},
+                        "required": None,
+                    },
+                }
+            ],
+        }
+
+        result = anthropic_messages_to_openai_responses_request(request)
+        schema = result["tools"][0]["parameters"]
+
+        assert "required" not in schema
+        assert request["tools"][0]["input_schema"]["required"] is None
 
     def test_multimodal_request_uses_correct_types(self):
         """Test that multimodal user messages use input_text and input_image types."""

--- a/llm_api_converter/tests/test_schema_utils.py
+++ b/llm_api_converter/tests/test_schema_utils.py
@@ -1,0 +1,32 @@
+"""Tests for provider-facing JSON Schema normalization."""
+
+from api_protocol_converter.converters.schema_utils import omit_null_required
+
+
+def test_omit_null_required_traverses_schema_keywords_only():
+    schema = {
+        "type": "object",
+        "required": None,
+        "$defs": {"address": {"type": "object", "required": None}},
+        "items": [{"type": "object", "required": None}],
+        "allOf": [{"type": "object", "required": None}],
+        "default": {"required": None},
+    }
+
+    result = omit_null_required(schema)
+
+    assert "required" not in result
+    assert "required" not in result["$defs"]["address"]
+    assert "required" not in result["items"][0]
+    assert "required" not in result["allOf"][0]
+    assert result["default"] == {"required": None}
+    assert schema["required"] is None
+
+
+def test_omit_null_required_preserves_non_schema_value():
+    value = [{"required": None}]
+
+    result = omit_null_required(value)
+
+    assert result == value
+    assert result is not value


### PR DESCRIPTION
## Summary

- omit `required: null` when converting Anthropic tool schemas to OpenAI Chat or Responses formats
- traverse nested JSON Schema keywords without modifying defaults/examples or the source payload
- add converter, utility, and backend integration regressions

## Verification

- `cd llm_api_converter && uv run --with pytest pytest -q` (63 passed)
- `cd backend && uv run pytest -q` (769 passed)
- new schema normalization module coverage: 97%

Closes GUL-77