### PR TITLE
GUL-91: fix cache prices in bulk model upgrades

### DIFF
--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -707,6 +707,10 @@ class ModelService:
             per_request_price=data.per_request_price,
             per_image_price=data.per_image_price,
             tiered_pricing=data.tiered_pricing,
+            cache_billing_enabled=bool(data.cache_billing_enabled),
+            cached_input_price=data.cached_input_price,
+            cached_output_price=data.cached_output_price,
+            cache_creation_input_price=data.cache_creation_input_price,
         )
 
         # Validate merged billing config before writing.
@@ -727,6 +731,10 @@ class ModelService:
                 "per_request_price": existing.per_request_price,
                 "per_image_price": existing.per_image_price,
                 "tiered_pricing": existing.tiered_pricing,
+                "cache_billing_enabled": existing.cache_billing_enabled,
+                "cached_input_price": existing.cached_input_price,
+                "cached_output_price": existing.cached_output_price,
+                "cache_creation_input_price": existing.cache_creation_input_price,
             }
             merged.update(update_data.model_dump(exclude_unset=True))
             ModelMappingProviderCreate(**merged)

--- a/backend/tests/integration/test_admin_models.py
+++ b/backend/tests/integration/test_admin_models.py
@@ -270,8 +270,13 @@ async def test_admin_bulk_upgrade_model_providers(db_session, monkeypatch):
                 "provider_id": provider_id,
                 "current_target_model_name": "old-model",
                 "new_target_model_name": "new-model",
-                "billing_mode": "per_request",
-                "per_request_price": 0.0021,
+                "billing_mode": "token_flat",
+                "input_price": 3,
+                "output_price": 4,
+                "cache_billing_enabled": True,
+                "cached_input_price": 0.3,
+                "cache_creation_input_price": 0.6,
+                "cached_output_price": 0.4,
             },
         )
         assert bulk_upgrade_resp.status_code == 200, bulk_upgrade_resp.text
@@ -283,8 +288,13 @@ async def test_admin_bulk_upgrade_model_providers(db_session, monkeypatch):
         assert len(items) == 2
         for item in items:
             assert item["target_model_name"] == "new-model"
-            assert item["billing_mode"] == "per_request"
-            assert item["per_request_price"] == 0.0021
+            assert item["billing_mode"] == "token_flat"
+            assert item["input_price"] == 3
+            assert item["output_price"] == 4
+            assert item["cache_billing_enabled"] is True
+            assert item["cached_input_price"] == 0.3
+            assert item["cache_creation_input_price"] == 0.6
+            assert item["cached_output_price"] == 0.4
 
     app.dependency_overrides = {}
 

--- a/backend/tests/unit/test_services/test_model_service_provider_mapping.py
+++ b/backend/tests/unit/test_services/test_model_service_provider_mapping.py
@@ -222,7 +222,6 @@ async def test_bulk_upgrade_provider_model_updates_all_matched_mappings(db_sessi
             output_price=2.5,
         )
     )
-
     updated_count = await service.bulk_upgrade_provider_model(
         ModelProviderBulkUpgradeRequest(
             provider_id=provider.id,
@@ -240,6 +239,88 @@ async def test_bulk_upgrade_provider_model_updates_all_matched_mappings(db_sessi
         assert mapping.target_model_name == "new-model"
         assert mapping.billing_mode == "per_request"
         assert mapping.per_request_price == 0.003
+
+
+@pytest.mark.asyncio
+async def test_bulk_upgrade_provider_model_updates_cache_pricing_only_for_matches(
+    db_session,
+):
+    model_repo = SQLAlchemyModelRepository(db_session)
+    provider_repo = SQLAlchemyProviderRepository(db_session)
+    service = ModelService(model_repo, provider_repo)
+
+    for requested_model in ("model-a", "model-b", "model-c"):
+        await model_repo.create_mapping(
+            ModelMappingCreate(requested_model=requested_model)
+        )
+
+    provider = await provider_repo.create(
+        ProviderCreate(
+            name="p-bulk-cache",
+            base_url="https://example.com",
+            protocol="openai",
+            api_type="chat",
+        )
+    )
+    for requested_model in ("model-a", "model-b"):
+        await service.create_provider_mapping(
+            ModelMappingProviderCreate(
+                requested_model=requested_model,
+                provider_id=provider.id,
+                target_model_name="old-model",
+                input_price=1.0,
+                output_price=2.0,
+            )
+        )
+    await service.create_provider_mapping(
+        ModelMappingProviderCreate(
+            requested_model="model-c",
+            provider_id=provider.id,
+            target_model_name="other-model",
+            input_price=7.0,
+            output_price=8.0,
+            cache_billing_enabled=False,
+        )
+    )
+
+    updated_count = await service.bulk_upgrade_provider_model(
+        ModelProviderBulkUpgradeRequest(
+            provider_id=provider.id,
+            current_target_model_name="old-model",
+            new_target_model_name="new-model",
+            billing_mode="token_flat",
+            input_price=3.0,
+            output_price=4.0,
+            cache_billing_enabled=True,
+            cached_input_price=0.3,
+            cache_creation_input_price=0.6,
+            cached_output_price=0.4,
+        )
+    )
+
+    assert updated_count == 2
+    mappings = await service.get_provider_mappings(provider_id=provider.id)
+    matched_mappings = [
+        mapping for mapping in mappings if mapping.requested_model != "model-c"
+    ]
+    assert len(matched_mappings) == 2
+    for mapping in matched_mappings:
+        assert mapping.target_model_name == "new-model"
+        assert mapping.billing_mode == "token_flat"
+        assert mapping.input_price == 3.0
+        assert mapping.output_price == 4.0
+        assert mapping.cache_billing_enabled is True
+        assert mapping.cached_input_price == 0.3
+        assert mapping.cache_creation_input_price == 0.6
+        assert mapping.cached_output_price == 0.4
+
+    unmatched = next(
+        mapping for mapping in mappings if mapping.requested_model == "model-c"
+    )
+    assert unmatched.target_model_name == "other-model"
+    assert unmatched.input_price == 7.0
+    assert unmatched.output_price == 8.0
+    assert unmatched.cache_billing_enabled is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- propagate cache billing settings and all cache prices during provider model bulk upgrades
- validate the merged cache pricing configuration before persistence
- cover matched and unmatched mappings through service and API regression tests

## Tests

- `cd backend && uv run pytest -q` (`770 passed`)
